### PR TITLE
Explicitly state Map types in RunMutation

### DIFF
--- a/lib/src/mutation.dart
+++ b/lib/src/mutation.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import './client.dart';
 
-typedef void RunMutation(Map variables);
+typedef void RunMutation(Map<String, dynamic> variables);
 
 typedef Widget MutationBuilder(
   RunMutation mutation, {


### PR DESCRIPTION
The new `RunMutation` type declaration inferencing will default to `<dynamic, dynamic>` without explicitly declaring the expectation. Because of this, the `Mutation` widgets fail to build with: 

`type '(Map<String, dynamic>) => void' is not a subtype of type '(Map<dynamic, dynamic>) => void'`

The stacktrace shows the error at 

`MutationState.build (package:graphql_flutter/src/mutation.dart:63:7)`

I believe the input should always be a `String` indexed map for the variables, so changing the type on the typedef from `Map` to `Map<String, dynamic>` should be fine.