### PR TITLE
Add onCompleted to the Mutation widget

### DIFF
--- a/example/app/lib/main.dart
+++ b/example/app/lib/main.dart
@@ -74,6 +74,24 @@ class _MyHomePageState extends State<MyHomePage> {
 
               return new Mutation(
                 mutations.addStar,
+                onCompleted: (Map<String, dynamic> data) {
+                  showDialog(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: Text('Thanks for your star!'),
+                        actions: <Widget>[
+                          SimpleDialogOption(
+                            child: Text('Dismiss'),
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
+                          )
+                        ],
+                      );
+                    }
+                  );
+                },
                 builder: (
                   addStar, {
                   bool loading,

--- a/example/app/pubspec.lock
+++ b/example/app/pubspec.lock
@@ -98,10 +98,10 @@ packages:
   graphql_flutter:
     dependency: "direct main"
     description:
-      name: graphql_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.0"
+      path: "../.."
+      relative: true
+    source: path
+    version: "0.4.1"
   html:
     dependency: transitive
     description:

--- a/example/app/pubspec.yaml
+++ b/example/app/pubspec.yaml
@@ -8,7 +8,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  graphql_flutter: ^0.4.1
+  graphql_flutter:
+    path: ../..
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -4,6 +4,8 @@ import '../client.dart';
 
 typedef void RunMutation(Map<String, dynamic> variables);
 
+typedef void OnMutationCompleted(Map<String, dynamic> data);
+
 typedef Widget MutationBuilder(
   RunMutation mutation, {
   @required bool loading,
@@ -16,10 +18,12 @@ class Mutation extends StatefulWidget {
     this.mutation, {
     Key key,
     @required this.builder,
+    this.onCompleted,
   }) : super(key: key);
 
   final String mutation;
   final MutationBuilder builder;
+  final OnMutationCompleted onCompleted;
 
   @override
   MutationState createState() => new MutationState();
@@ -47,6 +51,10 @@ class MutationState extends State<Mutation> {
         loading = false;
         data = result;
       });
+
+      if (widget.onCompleted != null) {
+        widget.onCompleted(result);
+      }
     } catch (e) {
       setState(() {
         loading = false;


### PR DESCRIPTION
This pull request introduces the `onCompleted` concept from the [Apollo client](https://www.apollographql.com/docs/react/essentials/mutations.html#props). The major use I have found for this so far has been for using the navigator to go to new pages or display alert dialogs after completing the mutation, as demonstrated in the example project. 