### PR TITLE
Authorization Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ void main() async {
     cache: new InMemoryCache(), // currently the only cache type we have implemented.
   );
   client.apiToken = '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>';
-  client.apiTokenPrefix = 'JWT'; // Default is 'Bearer'
-
+  // If you need a different auth token format, use getAuthorizationHeader callback function
+  client.getAuthorizationHeader = (String apiToken) => '<YOUR_CUSTOM_AUTHORIZATION_STRING>'
   ...
 }
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ void main() async {
     cache: new InMemoryCache(), // currently the only cache type we have implemented.
   );
   client.apiToken = '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>';
+  client.apiTokenPrefix = 'JWT'; // Default is 'Bearer'
 
   ...
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -12,7 +12,6 @@ class Client {
     String endPoint = '',
     String apiToken,
     InMemoryCache cache,
-    Map<String, String> Function(Map<String, String>) handleHeaders,
     String Function(String) getAuthorizationHeader,
   }) {
     this.endPoint = endPoint;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -11,13 +11,15 @@ class Client {
   Client({
     String endPoint = '',
     InMemoryCache cache,
+    String apiTokenPrefix = 'Bearer',
   }) {
     this.endPoint = endPoint;
     this.cache = cache;
-
+    this.apiTokenPrefix = apiTokenPrefix;
     this.client = new http.Client();
   }
 
+  String _apiTokenPrefix;
   String _endpoint;
   String _apiToken;
   InMemoryCache _cache;
@@ -37,15 +39,25 @@ class Client {
     _cache = cache;
   }
 
+  set apiTokenPrefix(String value) {
+    _apiTokenPrefix = value;
+  }
+
   // Getters
   String get endPoint => this._endpoint;
 
   String get apiToken => this._apiToken;
 
-  Map<String, String> get headers => {
-        'Authorization': 'Bearer $apiToken',
-        'Content-Type': 'application/json',
-      };
+  String get apiTokenPrefix => this._apiTokenPrefix;
+
+  Map<String, String> get headers {
+    Map<String, String> h = new Map();
+    if (apiToken != null) {
+      h['Authorization'] = '$apiTokenPrefix $apiToken';
+    }
+    h['Content-Type'] = 'application/json';
+    return h;
+  }
 
   InMemoryCache get cache => this._cache;
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -11,18 +11,18 @@ class Client {
   Client({
     String endPoint = '',
     InMemoryCache cache,
-    String apiTokenPrefix = 'Bearer',
+    Map<String, String> Function(Map<String, String>) handleHeaders,
   }) {
     this.endPoint = endPoint;
     this.cache = cache;
-    this.apiTokenPrefix = apiTokenPrefix;
     this.client = new http.Client();
+    this._handleHeaders = handleHeaders;
   }
 
-  String _apiTokenPrefix;
   String _endpoint;
   String _apiToken;
   InMemoryCache _cache;
+  Map<String, String> Function(Map<String, String>) _handleHeaders;
 
   http.Client client;
 
@@ -39,8 +39,8 @@ class Client {
     _cache = cache;
   }
 
-  set apiTokenPrefix(String value) {
-    _apiTokenPrefix = value;
+  set handleHeaders(Map<String, String> Function(Map<String, String>) value) {
+    _handleHeaders = value;
   }
 
   // Getters
@@ -48,15 +48,23 @@ class Client {
 
   String get apiToken => this._apiToken;
 
-  String get apiTokenPrefix => this._apiTokenPrefix;
+  Map<String, String> Function(Map<String, String>) get handleHeaders =>
+      this._handleHeaders;
 
   Map<String, String> get headers {
-    Map<String, String> h = new Map();
+    Map<String, String> headersMap = new Map();
+
+    headersMap['Content-Type'] = 'application/json';
+
     if (apiToken != null) {
-      h['Authorization'] = '$apiTokenPrefix $apiToken';
+      headersMap['Authorization'] = 'Bearer $apiToken';
     }
-    h['Content-Type'] = 'application/json';
-    return h;
+
+    if (handleHeaders != null) {
+      headersMap.addAll(handleHeaders(headersMap));
+    }
+
+    return headersMap;
   }
 
   InMemoryCache get cache => this._cache;


### PR DESCRIPTION
This prevents from sending a null Auth header (for troublesome endpoints), also allows modifying the prefix, if anyone is using other than the usual `Bearer`