### PR TITLE
`GraphqlProvider` and `GraphqlConsumer` widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [Graphql Provider](#graphql-provider)
   - [Queries](#queries)
   - [Mutations](#mutations)
+  - [Graphql Consumer](#graphql-consumer)
   - [Offline Cache](#offline-cache)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
@@ -198,6 +199,26 @@ new Mutation(
 }),
 
 ...
+```
+
+### Graphql Consumer
+
+You can always access the client direcly from the `GraphqlProvider` but to make it even easier you can also use the `GraphqlConsumer` widget.
+
+```dart
+  ...
+
+  return new GraphqlConsumer(
+    builder: (Client client) {
+      // do something with the client
+
+      return new Container(
+        child: new Text('Hello world'),
+      );
+    },
+  );
+
+  ...
 ```
 
 ### Offline Cache

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Graphql Provider](#graphql-provider)
   - [Queries](#queries)
   - [Mutations](#mutations)
   - [Offline Cache](#offline-cache)
@@ -36,7 +37,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 
 ## Usage
 
-To use the client it first needs to be initialized with an endpoint and cache. If your endpoint requires authentication you can provide it to the client by calling the setter `apiToken` on the `Client` class.
+To use the client it first needs to be initialized with an endpoint and cache. If your endpoint requires authentication you can provide it to the client contructor. If you need to change the api token at a later stage, you can call the setter `apiToken` on the `Client` class.
 
 > For this example we will use the public GitHub API.
 
@@ -45,17 +46,37 @@ To use the client it first needs to be initialized with an endpoint and cache. I
 
 import 'package:graphql_flutter/graphql_flutter.dart';
 
-void main() async {
-  client = new Client(
-    endPoint: 'https://api.github.com/graphql',
-    cache: new InMemoryCache(), // currently the only cache type we have implemented.
+void main() {
+  ValueNotifier<Client> client = new ValueNotifier(
+    new Client(
+      endPoint: 'https://api.github.com/graphql',
+      cache: new InMemoryCache(),
+      apiToken: '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>',
+    ),
   );
-  client.apiToken = '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>';
 
   ...
 }
 
 ...
+```
+
+### Graphql Provider
+
+In order to use the client, you app needs to be wrapped with the `GraphqlProvider` widget.
+
+```dart
+  ...
+
+  return new GraphqlProvider(
+    client: client,
+    child: new MaterialApp(
+      title: 'Flutter Demo',
+      ...
+    ),
+  );
+
+  ...
 ```
 
 ### Queries
@@ -183,19 +204,21 @@ new Mutation(
 
 The in-memory cache can automatically be saved to and restored from offline storage. Setting it up is as easy as wrapping your app with the `CacheProvider` widget.
 
+> Make sure the `CacheProvider` widget is inside the `GraphqlProvider` widget.
+
 ```dart
 ...
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return new CacheProvider(
-      child: new MaterialApp(
-        title: 'Flutter Demo',
-        theme: new ThemeData(
-          primarySwatch: Colors.blue,
+    return new GraphqlProvider(
+      client: client,
+      child: new CacheProvider(
+        child: new MaterialApp(
+          title: 'Flutter Demo',
+          ...
         ),
-        home: new MyHomePage(title: 'Flutter Demo Home Page'),
       ),
     );
   }
@@ -212,8 +235,10 @@ This is currently our roadmap, please feel free to request additions/changes.
 | :---------------------- | :------: |
 | Basic queries           |    ✅    |
 | Basic mutations         |    ✅    |
+| Basic subscriptions     |    🔜    |
 | Query variables         |    ✅    |
 | Mutation variables      |    ✅    |
+| Subscription variables  |    🔜    |
 | Query polling           |    ✅    |
 | In memory caching       |    ✅    |
 | Offline caching         |    ✅    |
@@ -232,6 +257,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 <!-- prettier-ignore -->
 | [<img src="https://avatars2.githubusercontent.com/u/4757453?v=4" width="100px;"/><br /><sub><b>Eustatiu Dima</b></sub>](http://eusdima.com)<br />[🐛](https://github.com/zino-app/graphql-flutter/issues?q=author%3Aeusdima "Bug reports") [💻](https://github.com/zino-app/graphql-flutter/commits?author=eusdima "Code") [📖](https://github.com/zino-app/graphql-flutter/commits?author=eusdima "Documentation") [💡](#example-eusdima "Examples") [🤔](#ideas-eusdima "Ideas, Planning, & Feedback") [👀](#review-eusdima "Reviewed Pull Requests") | [<img src="https://avatars3.githubusercontent.com/u/17142193?v=4" width="100px;"/><br /><sub><b>Zino Hofmann</b></sub>](https://github.com/HofmannZ)<br />[🐛](https://github.com/zino-app/graphql-flutter/issues?q=author%3AHofmannZ "Bug reports") [💻](https://github.com/zino-app/graphql-flutter/commits?author=HofmannZ "Code") [📖](https://github.com/zino-app/graphql-flutter/commits?author=HofmannZ "Documentation") [💡](#example-HofmannZ "Examples") [🤔](#ideas-HofmannZ "Ideas, Planning, & Feedback") [🚇](#infra-HofmannZ "Infrastructure (Hosting, Build-Tools, etc)") [👀](#review-HofmannZ "Reviewed Pull Requests") | [<img src="https://avatars2.githubusercontent.com/u/15068096?v=4" width="100px;"/><br /><sub><b>Harkirat Saluja</b></sub>](https://github.com/jinxac)<br />[📖](https://github.com/zino-app/graphql-flutter/commits?author=jinxac "Documentation") [🤔](#ideas-jinxac "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/5178217?v=4" width="100px;"/><br /><sub><b>Chris Muthig</b></sub>](https://github.com/camuthig)<br />[💻](https://github.com/zino-app/graphql-flutter/commits?author=camuthig "Code") [📖](https://github.com/zino-app/graphql-flutter/commits?author=camuthig "Documentation") [💡](#example-camuthig "Examples") [🤔](#ideas-camuthig "Ideas, Planning, & Feedback") | [<img src="https://avatars1.githubusercontent.com/u/7611406?v=4" width="100px;"/><br /><sub><b>Cal Pratt</b></sub>](http://stackoverflow.com/users/3280538/flkes)<br />[🐛](https://github.com/zino-app/graphql-flutter/issues?q=author%3Acal-pratt "Bug reports") [💻](https://github.com/zino-app/graphql-flutter/commits?author=cal-pratt "Code") [📖](https://github.com/zino-app/graphql-flutter/commits?author=cal-pratt "Documentation") [💡](#example-cal-pratt "Examples") [🤔](#ideas-cal-pratt "Ideas, Planning, & Feedback") |
 | :---: | :---: | :---: | :---: | :---: |
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind are welcome!

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,23 +9,25 @@ void main() => runApp(new MyApp());
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    Client client = new Client(
-      endPoint: 'https://api.github.com/graphql',
-      cache: new InMemoryCache(),
+    ValueNotifier<Client> client = new ValueNotifier(
+      new Client(
+        endPoint: 'https://api.github.com/graphql',
+        cache: new InMemoryCache(),
+        apiToken: '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>',
+      ),
     );
-    client.apiToken = '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>';
 
     return new GraphqlProvider(
       client: client,
-      // child: new CacheProvider(
-      child: new MaterialApp(
-        title: 'Flutter Demo',
-        theme: new ThemeData(
-          primarySwatch: Colors.blue,
+      child: new CacheProvider(
+        child: new MaterialApp(
+          title: 'Flutter Demo',
+          theme: new ThemeData(
+            primarySwatch: Colors.blue,
+          ),
+          home: new MyHomePage(title: 'Flutter Demo Home Page'),
         ),
-        home: new MyHomePage(title: 'Flutter Demo Home Page'),
       ),
-      // ),
     );
   }
 }
@@ -51,7 +53,7 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       body: new Query(
         queries.readRepositories,
-        // pollInterval: 1,s
+        pollInterval: 1,
         builder: ({
           bool loading,
           Map data,
@@ -83,7 +85,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 }) {
                   if (data.isNotEmpty) {
                     repository['viewerHasStarred'] =
-                      data['addStar']['starrable']['viewerHasStarred'];
+                        data['addStar']['starrable']['viewerHasStarred'];
                   }
 
                   return new ListTile(
@@ -101,20 +103,21 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
                 onCompleted: (Map<String, dynamic> data) {
                   showDialog(
-                      context: context,
-                      builder: (BuildContext context) {
-                        return AlertDialog(
-                          title: Text('Thanks for your star!'),
-                          actions: <Widget>[
-                            SimpleDialogOption(
-                              child: Text('Dismiss'),
-                              onPressed: () {
-                                Navigator.of(context).pop();
-                              },
-                            )
-                          ],
-                        );
-                      });
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: Text('Thanks for your star!'),
+                        actions: <Widget>[
+                          SimpleDialogOption(
+                            child: Text('Dismiss'),
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
+                          )
+                        ],
+                      );
+                    },
+                  );
                 },
               );
             },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,20 +4,20 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import './queries/readRepositories.dart' as queries;
 import './mutations/addStar.dart' as mutations;
 
-void main() {
-  client = new Client(
-    endPoint: 'https://api.github.com/graphql',
-    cache: new InMemoryCache(),
-  );
-  client.apiToken = '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>';
-
-  runApp(new MyApp());
-}
+void main() => runApp(new MyApp());
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return new CacheProvider(
+    Client client = new Client(
+      endPoint: 'https://api.github.com/graphql',
+      cache: new InMemoryCache(),
+    );
+    client.apiToken = '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>';
+
+    return new GraphqlProvider(
+      client: client,
+      // child: new CacheProvider(
       child: new MaterialApp(
         title: 'Flutter Demo',
         theme: new ThemeData(
@@ -25,6 +25,7 @@ class MyApp extends StatelessWidget {
         ),
         home: new MyHomePage(title: 'Flutter Demo Home Page'),
       ),
+      // ),
     );
   }
 }
@@ -50,7 +51,7 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       body: new Query(
         queries.readRepositories,
-        pollInterval: 1,
+        // pollInterval: 1,s
         builder: ({
           bool loading,
           Map data,
@@ -95,21 +96,20 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
                 onCompleted: (Map<String, dynamic> data) {
                   showDialog(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return AlertDialog(
-                        title: Text('Thanks for your star!'),
-                        actions: <Widget>[
-                          SimpleDialogOption(
-                            child: Text('Dismiss'),
-                            onPressed: () {
-                              Navigator.of(context).pop();
-                            },
-                          )
-                        ],
-                      );
-                    }
-                  );
+                      context: context,
+                      builder: (BuildContext context) {
+                        return AlertDialog(
+                          title: Text('Thanks for your star!'),
+                          actions: <Widget>[
+                            SimpleDialogOption(
+                              child: Text('Dismiss'),
+                              onPressed: () {
+                                Navigator.of(context).pop();
+                              },
+                            )
+                          ],
+                        );
+                      });
                 },
               );
             },

--- a/lib/graphql_flutter.dart
+++ b/lib/graphql_flutter.dart
@@ -4,6 +4,7 @@ export 'package:graphql_flutter/src/client.dart';
 
 export 'package:graphql_flutter/src/cache/in_memory.dart';
 
+export 'package:graphql_flutter/src/widgets/graphql_provider.dart';
+export 'package:graphql_flutter/src/widgets/cache_provider.dart';
 export 'package:graphql_flutter/src/widgets/query.dart';
 export 'package:graphql_flutter/src/widgets/mutation.dart';
-export 'package:graphql_flutter/src/widgets/cache_provider.dart';

--- a/lib/graphql_flutter.dart
+++ b/lib/graphql_flutter.dart
@@ -4,6 +4,7 @@ export './src/client.dart';
 
 export './src/cache/in_memory.dart';
 
+export './src/widgets/graphql_provider.dart';
+export './src/widgets/cache_provider.dart';
 export './src/widgets/query.dart';
 export './src/widgets/mutation.dart';
-export './src/widgets/cache_provider.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -5,8 +5,6 @@ import 'package:http/http.dart' as http;
 
 import './cache/in_memory.dart';
 
-Client client;
-
 class Client {
   Client({
     String endPoint = '',

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -9,10 +9,14 @@ class Client {
   Client({
     String endPoint = '',
     InMemoryCache cache,
+    String apiToken,
   }) {
+    assert(endPoint != null);
+    assert(cache != null);
+
     this.endPoint = endPoint;
     this.cache = cache;
-
+    this.apiToken = apiToken;
     this.client = new http.Client();
   }
 

--- a/lib/src/widgets/cache_provider.dart
+++ b/lib/src/widgets/cache_provider.dart
@@ -1,58 +1,58 @@
-import 'package:flutter/material.dart';
-import '../client.dart';
+// import 'package:flutter/material.dart';
+// import '../client.dart';
 
-class CacheProvider extends StatefulWidget {
-  const CacheProvider({
-    Key key,
-    @required this.child,
-  }) : super(key: key);
+// class CacheProvider extends StatefulWidget {
+//   const CacheProvider({
+//     Key key,
+//     @required this.child,
+//   }) : super(key: key);
 
-  final Widget child;
+//   final Widget child;
 
-  @override
-  _CacheProviderState createState() => new _CacheProviderState();
-}
+//   @override
+//   _CacheProviderState createState() => new _CacheProviderState();
+// }
 
-class _CacheProviderState extends State<CacheProvider>
-    with WidgetsBindingObserver {
-  @override
-  void initState() {
-    super.initState();
+// class _CacheProviderState extends State<CacheProvider>
+//     with WidgetsBindingObserver {
+//   @override
+//   void initState() {
+//     super.initState();
 
-    client.cache.restore();
+//     client.cache.restore();
 
-    WidgetsBinding.instance.addObserver(this);
-  }
+//     WidgetsBinding.instance.addObserver(this);
+//   }
 
-  @override
-  void dispose() {
-    super.dispose();
+//   @override
+//   void dispose() {
+//     super.dispose();
 
-    WidgetsBinding.instance.removeObserver(this);
-  }
+//     WidgetsBinding.instance.removeObserver(this);
+//   }
 
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    switch (state) {
-      case AppLifecycleState.inactive:
-        client.cache.save();
-        break;
+//   @override
+//   void didChangeAppLifecycleState(AppLifecycleState state) {
+//     switch (state) {
+//       case AppLifecycleState.inactive:
+//         client.cache.save();
+//         break;
 
-      case AppLifecycleState.paused:
-        client.cache.save();
-        break;
+//       case AppLifecycleState.paused:
+//         client.cache.save();
+//         break;
 
-      case AppLifecycleState.suspending:
-        break;
+//       case AppLifecycleState.suspending:
+//         break;
 
-      case AppLifecycleState.resumed:
-        client.cache.restore();
-        break;
-    }
-  }
+//       case AppLifecycleState.resumed:
+//         client.cache.restore();
+//         break;
+//     }
+//   }
 
-  @override
-  Widget build(BuildContext context) {
-    return widget.child;
-  }
-}
+//   @override
+//   Widget build(BuildContext context) {
+//     return widget.child;
+//   }
+// }

--- a/lib/src/widgets/cache_provider.dart
+++ b/lib/src/widgets/cache_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:graphql_flutter/src/client.dart';
+import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 
 class CacheProvider extends StatefulWidget {
   const CacheProvider({
@@ -20,9 +21,17 @@ class _CacheProviderState extends State<CacheProvider>
   void initState() {
     super.initState();
 
-    client.cache.restore();
-
     WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeDependencies() {
+    Client client = GraphqlProvider.of(context).value;
+    assert(client != null);
+
+    client.cache?.restore();
+
+    super.didChangeDependencies();
   }
 
   @override
@@ -34,26 +43,28 @@ class _CacheProviderState extends State<CacheProvider>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    /// Gets the client from the closest wrapping [GraphqlProvider].
+    Client client = GraphqlProvider.of(context).value;
+    assert(client != null);
+
     switch (state) {
       case AppLifecycleState.inactive:
-        client.cache.save();
+        client.cache?.save();
         break;
 
       case AppLifecycleState.paused:
-        client.cache.save();
+        client.cache?.save();
         break;
 
       case AppLifecycleState.suspending:
         break;
 
       case AppLifecycleState.resumed:
-        client.cache.restore();
+        client.cache?.restore();
         break;
     }
   }
 
   @override
-  Widget build(BuildContext context) {
-    return widget.child;
-  }
+  Widget build(BuildContext context) => widget.child;
 }

--- a/lib/src/widgets/graphql_consumer.dart
+++ b/lib/src/widgets/graphql_consumer.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:graphql_flutter/src/client.dart';
+import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
+
+typedef Widget GraphqlConsumerBuilder(Client client);
+
+class GraphqlConsumer extends StatelessWidget {
+  GraphqlConsumer({
+    final Key key,
+    @required this.builder,
+  }) : super(key: key);
+
+  final GraphqlConsumerBuilder builder;
+
+  Widget build(BuildContext context) {
+    /// Gets the client from the closest wrapping [GraphqlProvider].
+    Client client = GraphqlProvider.of(context).value;
+    assert(client != null);
+
+    return builder(client);
+  }
+}

--- a/lib/src/widgets/graphql_provider.dart
+++ b/lib/src/widgets/graphql_provider.dart
@@ -1,22 +1,66 @@
 import 'package:flutter/widgets.dart';
 
-import '../client.dart';
+import 'package:graphql_flutter/src/client.dart';
 
-class GraphqlProvider extends InheritedWidget {
-  GraphqlProvider({
+class GraphqlProvider extends StatefulWidget {
+  const GraphqlProvider({
     Key key,
-    @required this.client,
-    @required Widget child,
-  }) : super(key: key, child: child);
+    this.client,
+    this.child,
+  }) : super(key: key);
 
-  final Client client;
+  final ValueNotifier<Client> client;
+  final Widget child;
 
-  @override
-  bool updateShouldNotify(GraphqlProvider oldWidget) {
-    return client != oldWidget.client;
+  static ValueNotifier<Client> of(BuildContext context) {
+    _InheritedGraphqlProvider inheritedGraphqlProvider =
+        context.inheritFromWidgetOfExactType(_InheritedGraphqlProvider);
+
+    return inheritedGraphqlProvider.client;
   }
 
-  static GraphqlProvider of(BuildContext context) {
-    return context.inheritFromWidgetOfExactType(GraphqlProvider);
+  @override
+  State<StatefulWidget> createState() => new _GraphqlProviderState();
+}
+
+class _GraphqlProviderState extends State<GraphqlProvider> {
+  void didValueChange() => setState(() {});
+
+  @override
+  initState() {
+    super.initState();
+
+    widget.client.addListener(didValueChange);
+  }
+
+  @override
+  dispose() {
+    widget.client?.removeListener(didValueChange);
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new _InheritedGraphqlProvider(
+      client: widget.client,
+      child: widget.child,
+    );
+  }
+}
+
+class _InheritedGraphqlProvider extends InheritedWidget {
+  _InheritedGraphqlProvider({
+    this.client,
+    this.child,
+  }) : clientValue = client.value;
+
+  final ValueNotifier<Client> client;
+  final Widget child;
+  final Client clientValue;
+
+  @override
+  bool updateShouldNotify(_InheritedGraphqlProvider oldWidget) {
+    return clientValue != oldWidget.clientValue;
   }
 }

--- a/lib/src/widgets/graphql_provider.dart
+++ b/lib/src/widgets/graphql_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+
+import '../client.dart';
+
+class GraphqlProvider extends InheritedWidget {
+  GraphqlProvider({
+    Key key,
+    @required this.client,
+    @required Widget child,
+  }) : super(key: key, child: child);
+
+  final Client client;
+
+  @override
+  bool updateShouldNotify(GraphqlProvider oldWidget) {
+    return client != oldWidget.client;
+  }
+
+  static GraphqlProvider of(BuildContext context) {
+    return context.inheritFromWidgetOfExactType(GraphqlProvider);
+  }
+}

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -69,10 +69,8 @@ class MutationState extends State<Mutation> {
       };
 
   Widget build(BuildContext context) {
-    final Client client = GraphqlProvider.of(context).client;
-
     return widget.builder(
-      runMutation(client),
+      runMutation(GraphqlProvider.of(context).client),
       loading: loading,
       error: error,
       data: data,

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../client.dart';
+import './graphql_provider.dart';
 
 typedef void RunMutation(Map<String, dynamic> variables);
 
@@ -34,41 +35,44 @@ class MutationState extends State<Mutation> {
   Map<String, dynamic> data = {};
   String error = '';
 
-  void runMutation(Map<String, dynamic> variables) async {
-    setState(() {
-      loading = true;
-      error = '';
-      data = {};
-    });
+  RunMutation runMutation(Client client) =>
+      (Map<String, dynamic> variables) async {
+        setState(() {
+          loading = true;
+          error = '';
+          data = {};
+        });
 
-    try {
-      final Map<String, dynamic> result = await client.query(
-        query: widget.mutation,
-        variables: variables,
-      );
+        try {
+          final Map<String, dynamic> result = await client.query(
+            query: widget.mutation,
+            variables: variables,
+          );
 
-      setState(() {
-        loading = false;
-        data = result;
-      });
+          setState(() {
+            loading = false;
+            data = result;
+          });
 
-      if (widget.onCompleted != null) {
-        widget.onCompleted(result);
-      }
-    } catch (e) {
-      setState(() {
-        loading = false;
-        error = 'GQL ERROR';
-      });
+          if (widget.onCompleted != null) {
+            widget.onCompleted(result);
+          }
+        } catch (e) {
+          setState(() {
+            loading = false;
+            error = 'GQL ERROR';
+          });
 
-      // TODO: Handle error
-      print(e);
-    }
-  }
+          // TODO: Handle error
+          print(e);
+        }
+      };
 
   Widget build(BuildContext context) {
+    final Client client = GraphqlProvider.of(context).client;
+
     return widget.builder(
-      runMutation,
+      runMutation(client),
       loading: loading,
       error: error,
       data: data,

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/widgets.dart';
 
 import 'package:graphql_flutter/src/client.dart';
+import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 
 typedef void RunMutation(Map<String, dynamic> variables);
-
 typedef void OnMutationCompleted(Map<String, dynamic> data);
-
 typedef Widget MutationBuilder(
   RunMutation mutation, {
   @required bool loading,
@@ -35,6 +34,10 @@ class MutationState extends State<Mutation> {
   String error = '';
 
   void runMutation(Map<String, dynamic> variables) async {
+    /// Gets the client from the closest wrapping [GraphqlProvider].
+    Client client = GraphqlProvider.of(context).value;
+    assert(client != null);
+
     setState(() {
       loading = true;
       error = '';

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -33,12 +33,14 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
   Map<String, dynamic> data = {};
   String error = '';
   Duration pollInterval;
+  Timer pollTimer;
+  bool initialFetch = false;
 
   @override
   void initState() {
     super.initState();
 
-    if (widget.pollInterval != null) {
+    if (widget.pollInterval is int) {
       pollInterval = new Duration(seconds: widget.pollInterval);
     }
   }
@@ -71,8 +73,8 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
         data = result;
       });
 
-      if (widget.pollInterval != null) {
-        new Timer(pollInterval, () => getQueryResult(client));
+      if (pollInterval is Duration && !(pollTimer is Timer)) {
+        pollTimer = new Timer(pollInterval, () => getQueryResult(client));
       }
     } catch (e) {
       if (data == {}) {
@@ -82,8 +84,8 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
         });
       }
 
-      if (widget.pollInterval != null) {
-        new Timer(pollInterval, () => getQueryResult(client));
+      if (pollInterval is Duration && !(pollTimer is Timer)) {
+        pollTimer = new Timer(pollInterval, () => getQueryResult(client));
       }
 
       // TODO: handle error
@@ -92,9 +94,11 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
   }
 
   Widget build(BuildContext context) {
-    final Client client = GraphqlProvider.of(context).client;
+    if (!initialFetch) {
+      initialFetch = true;
 
-    getQueryResult(client);
+      getQueryResult(GraphqlProvider.of(context).client);
+    }
 
     return widget.builder(
       loading: loading,

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 
 import '../client.dart';
+import './graphql_provider.dart';
 
 typedef Widget QueryBuilder({
   @required bool loading,
@@ -40,11 +41,9 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
     if (widget.pollInterval != null) {
       pollInterval = new Duration(seconds: widget.pollInterval);
     }
-
-    getQueryResult();
   }
 
-  void getQueryResult() async {
+  void getQueryResult(Client client) async {
     try {
       final Map<String, dynamic> result = client.readQuery(
         query: widget.query,
@@ -59,6 +58,7 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
     } catch (e) {
       print(e.toString());
     }
+
     try {
       final Map<String, dynamic> result = await client.query(
         query: widget.query,
@@ -72,7 +72,7 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
       });
 
       if (widget.pollInterval != null) {
-        new Timer(pollInterval, getQueryResult);
+        new Timer(pollInterval, () => getQueryResult(client));
       }
     } catch (e) {
       if (data == {}) {
@@ -83,7 +83,7 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
       }
 
       if (widget.pollInterval != null) {
-        new Timer(pollInterval, getQueryResult);
+        new Timer(pollInterval, () => getQueryResult(client));
       }
 
       // TODO: handle error
@@ -92,6 +92,10 @@ class QueryState extends State<Query> with WidgetsBindingObserver {
   }
 
   Widget build(BuildContext context) {
+    final Client client = GraphqlProvider.of(context).client;
+
+    getQueryResult(client);
+
     return widget.builder(
       loading: loading,
       error: error,

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -33,7 +33,7 @@ class QueryState extends State<Query> {
   Map<String, dynamic> data = {};
   String error = '';
 
-  bool initialFetch = false;
+  bool initialFetch = true;
   Duration pollInterval;
   Timer pollTimer;
   Map currentVariables = new Map();
@@ -131,9 +131,8 @@ class QueryState extends State<Query> {
   }
 
   Widget build(BuildContext context) {
-    if (!initialFetch) {
-      initialFetch = true;
-
+    if (initialFetch) {
+      initialFetch = false;
       currentVariables = widget.variables;
 
       getQueryResult();

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 
 import 'package:graphql_flutter/src/client.dart';
+import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 
 typedef Widget QueryBuilder({
   @required bool loading,
@@ -63,6 +64,10 @@ class QueryState extends State<Query> {
   }
 
   void getQueryResult() async {
+    /// Gets the client from the closest wrapping [GraphqlProvider].
+    Client client = GraphqlProvider.of(context).value;
+    assert(client != null);
+
     try {
       final Map<String, dynamic> result = client.readQuery(
         query: widget.query,
@@ -77,6 +82,7 @@ class QueryState extends State<Query> {
     } catch (e) {
       print(e.toString());
     }
+
     try {
       final Map<String, dynamic> result = await client.query(
         query: widget.query,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,42 +17,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://www.dartlang.org/tools/pub/pubspec
-
-# The following section is specific to Flutter.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.io/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.io/custom-fonts/#from-packages
-
 environment:
     sdk: ">=2.0.0-dev.52.0"


### PR DESCRIPTION
This PR adds the `GraphqlProvider` and `GraphqlConsumer` widgets as discussed in #16.

### Breaking change

- The library now requires your app to be wrapped with the `GraphqlProvider` widget @HofmannZ
- The global `client` variable is no longer available. Instead use the `GraphqlConsumer` widget

#### Fixes / Enhancements

- Added the `GraphqlProvider` widget. The client is now stored in an `InheritedWidget`, and can be accessed anywhere within the app.

```dart
Client client = GraphqlProvider.of(context).value;
```

- Added the `GraphqlConsumer` widget. For ease of use we added a widget that uses the same builder structure as the `Query` and `Mutation` widgets. 

> Under the hood it access the client from the `BuildContext`.

- Added the option to optionally provide the `apiToken` to the `Client` constructor. It is still possible to set the `apiToken` with setter method.

```dart
  return new GraphqlConsumer(
    builder: (Client client) {
      // do something with the client

      return new Container();
    },
  );
```

#### Docs

- Added documentation for the new `GraphqlProvider`
- Added documentation for the new `GraphqlConsumer`
- Changed the setup instructions to include the new widgets
- Changed the example to include the new widgets
