### PR TITLE
Fix mutations example bug not updating star bool

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -80,6 +80,11 @@ class _MyHomePageState extends State<MyHomePage> {
                   Map data,
                   String error,
                 }) {
+                  if (data.isNotEmpty) {
+                    repository['viewerHasStarred'] =
+                      data['addStar']['starrable']['viewerHasStarred'];
+                  }
+
                   return new ListTile(
                     leading: repository['viewerHasStarred']
                         ? const Icon(Icons.star, color: Colors.amber)

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -74,7 +74,7 @@ class Client {
 
     if (jsonResponse['errors'] != null && jsonResponse['errors'].length > 0) {
       throw new Exception(
-        'Error returned by the server in the query' + jsonResponse['errors'],
+        'Error returned by the server in the query' + jsonResponse['errors'].toString(),
       );
     }
 

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -55,7 +55,7 @@ class MutationState extends State<Mutation> {
       if (widget.onCompleted != null) {
         widget.onCompleted(result);
       }
-    } catch (e) {
+    } on Error catch (e) {
       setState(() {
         loading = false;
         error = 'GQL ERROR';
@@ -63,6 +63,7 @@ class MutationState extends State<Mutation> {
 
       // TODO: Handle error
       print(e);
+      print(e.stackTrace);
     }
   }
 


### PR DESCRIPTION
Got caught in a few small places while trying to launch the example.

Added a stack trace in `mutation.dart`. The current implementation only outputs the high-level description making it difficult to track where the exception is coming from.

Exception logic was throwing in `client.dart`. It is possible for `jsonResponse['errors']` to be a `List<dynamic>` instead of a `String`

Update the local data in the Mutation Widget based on the result of the Mutation. This was causing stars to remain uncolored after performing a tap