### PR TITLE
Subscription SocketClient and Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,59 @@ class MyApp extends StatelessWidget {
 ...
 ```
 
+### Subscriptions (Experimental)
+
+The syntax for subscriptions is again similar to a query, however, this utilizes WebSockets and dart Streams to provide real-time updates from a server.
+Before subscriptions can performed the following code is required for initializing the global `socketClient` instance.
+
+```dart
+socketClient = await SocketClient.connect('ws://coolserver.com/graphql');
+
+// Example non-flutter usage:
+final String operationName = "SubscriptionQuery";
+final String query = """subscription $operationName(\$requestId: String!) {
+  requestSubscription(requestId: \$requestId) {
+    requestData
+  }
+}""";
+final dynamic variables = {
+  'requestId': 'My Request',
+};
+socketClient
+    .subscribe(SubscriptionRequest(operationName, query, variables))
+    .listen(print);
+```
+
+Once the `socketClient` has been initialized it can be used by the `Subscription` `Widget`
+
+```dart
+class _MyHomePageState extends State<MyHomePage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Subscription(
+          operationName,
+          query,
+          variables: variables,
+          builder: ({
+            bool loading,
+            dynamic payload,
+            dynamic error,
+          }) {
+            if (payload != null) {
+              return Text(payload['requestSubscription']['requestData']);
+            } else {
+              return Text('Data not found');
+            }
+          }
+        ),
+      )
+    );
+  }
+}
+```
+
 ## Roadmap
 
 This is currently our roadmap, please feel free to request additions/changes.

--- a/lib/graphql_flutter.dart
+++ b/lib/graphql_flutter.dart
@@ -1,10 +1,15 @@
 library graphql_flutter;
 
 export 'package:graphql_flutter/src/client.dart';
+export 'package:graphql_flutter/src/socket_client.dart';
 
 export 'package:graphql_flutter/src/cache/in_memory.dart';
 
-export 'package:graphql_flutter/src/widgets/graphql_provider.dart';
+export 'package:graphql_flutter/src/websocket/messages.dart';
+export 'package:graphql_flutter/src/websocket/socket.dart';
+
 export 'package:graphql_flutter/src/widgets/cache_provider.dart';
+export 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 export 'package:graphql_flutter/src/widgets/query.dart';
 export 'package:graphql_flutter/src/widgets/mutation.dart';
+export 'package:graphql_flutter/src/widgets/subscription.dart';

--- a/lib/src/socket_client.dart
+++ b/lib/src/socket_client.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:uuid/uuid.dart';
+
+import '../graphql_flutter.dart';
+
+SocketClient socketClient;
+
+class SocketClient {
+  static Future<SocketClient> connect(
+    final String endPoint, {
+    final List<String> protocols = const [
+      'graphql-ws',
+    ],
+    final Map<String, String> headers = const {
+      'content-type': 'application/json',
+    },
+  }) async {
+    return SocketClient(GraphQLSocket(await WebSocket.connect(
+      endPoint,
+      protocols: protocols,
+      headers: headers,
+    )));
+  }
+
+  final Uuid _uuid = Uuid();
+  final GraphQLSocket _socket;
+
+  SocketClient(this._socket) {
+    _socket.connectionAck.listen(print);
+    _socket.connectionError.listen(print);
+    _socket.unknownData.listen(print);
+    _socket.write(InitOperation());
+  }
+
+  Stream<SubscriptionData> subscribe(final SubscriptionRequest payload) {
+    final String id = _uuid.v4();
+
+    final StreamController<SubscriptionData> response =
+        StreamController<SubscriptionData>();
+
+    final Stream<SubscriptionComplete> complete = _socket.subscriptionComplete
+        .where((message) => message.id == id)
+        .take(1);
+
+    final Stream<SubscriptionData> data = _socket.subscriptionData
+        .where((message) => message.id == id)
+        .takeWhile((_) => !response.isClosed);
+
+    final Stream<SubscriptionError> error = _socket.subscriptionError
+        .where((message) => message.id == id)
+        .takeWhile((_) => !response.isClosed);
+
+    complete.listen((_) => response.close());
+    data.listen((message) => response.add(message));
+    error.listen((message) => response.addError(message));
+
+    response.onListen = () => _socket.write(StartOperation(id, payload));
+    response.onCancel = () => _socket.write(StopOperation(id));
+
+    return response.stream;
+  }
+}

--- a/lib/src/websocket/messages.dart
+++ b/lib/src/websocket/messages.dart
@@ -1,0 +1,195 @@
+/// These messages represent the structures used for Client-server communication
+/// in a GraphQL web-socket subscription. Each message is represented in a JSON
+/// format where the data type is denoted by the `type` field.
+
+/// A list of constants used for identifying message types
+class MessageTypes {
+  MessageTypes._();
+
+  // client connections
+  static const GQL_CONNECTION_INIT = 'connection_init';
+  static const GQL_CONNECTION_TERMINATE = 'connection_terminate';
+
+  // server connections
+  static const GQL_CONNECTION_ACK = 'connection_ack';
+  static const GQL_CONNECTION_ERROR = 'connection_error';
+
+  // client operations
+  static const GQL_START = 'start';
+  static const GQL_STOP = 'stop';
+
+  // server operations
+  static const GQL_DATA = 'data';
+  static const GQL_ERROR = 'error';
+  static const GQL_COMPLETE = 'complete';
+
+  // default tag for use in identifying issues
+  static const GQL_UNKNOWN = 'unknown';
+}
+
+abstract class JsonSerializable {
+  dynamic toJson();
+
+  @override
+  String toString() => toJson().toString();
+}
+
+/// Base type for representing a server-client subscription message.
+abstract class GraphQLSocketMessage extends JsonSerializable {
+  final String type;
+
+  GraphQLSocketMessage(this.type);
+}
+
+/// After establishing a connection with the server, the client will
+/// send this message to tell the server that it is ready to begin sending
+/// new subscription queries.
+class InitOperation extends GraphQLSocketMessage {
+  InitOperation() : super(MessageTypes.GQL_CONNECTION_INIT);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+  };
+}
+
+/// Represent the payload used during a Start query operation.
+/// The operationName should match one of the top level query definitions
+/// defined in the query provided. Additional variables can be provided
+/// and sent to the server for processing.
+class SubscriptionRequest extends JsonSerializable {
+  final String operationName;
+  final String query;
+  final dynamic variables;
+
+  SubscriptionRequest(this.operationName, this.query, this.variables);
+
+  @override
+  dynamic toJson() => {
+    'operationName': operationName,
+    'query': query,
+    'variables': variables,
+  };
+}
+
+/// A message to tell the server to create a subscription. The contents of the
+/// query will be defined by the payload request. The id provided will be used
+/// to tag messages such that they can be identified for this subscription
+/// instance. id values should be unique and not be re-used during the lifetime
+/// of the server.
+class StartOperation extends GraphQLSocketMessage {
+  final String id;
+  final SubscriptionRequest payload;
+
+  StartOperation(this.id, this.payload) : super(MessageTypes.GQL_START);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+    'id': id,
+    'payload': payload,
+  };
+}
+
+/// Tell the server to stop sending subscription data for a particular
+/// subscription instance. See StartOperation
+class StopOperation extends GraphQLSocketMessage {
+  final String id;
+
+  StopOperation(this.id) : super(MessageTypes.GQL_STOP);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+    'id': id,
+  };
+}
+
+/// The server will send this acknowledgment message after receiving the init
+/// command from the client if the init was successful.
+class ConnectionAck extends GraphQLSocketMessage {
+  ConnectionAck() : super(MessageTypes.GQL_CONNECTION_ACK);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+  };
+}
+
+/// The server will send this error message after receiving the init command
+/// from the client if the init was not successful.
+class ConnectionError extends GraphQLSocketMessage {
+  final dynamic payload;
+
+  ConnectionError(this.payload) : super(MessageTypes.GQL_CONNECTION_ERROR);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+    'payload': payload,
+  };
+}
+
+/// Data sent from the server to the client with subscription data or error
+/// payload. The user should check the errors result before processing the
+/// data value. These error are from the query resolvers.
+class SubscriptionData extends GraphQLSocketMessage {
+  final String id;
+  final dynamic data;
+  final dynamic errors;
+
+  SubscriptionData(this.id, this.data, this.errors)
+      : super(MessageTypes.GQL_DATA);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+    'data': data,
+    'errors': errors,
+  };
+}
+
+/// Errors sent from the server to the client if the subscription operation was
+/// not successful, usually due to GraphQL validation errors.
+class SubscriptionError extends GraphQLSocketMessage {
+  final String id;
+  final dynamic payload;
+
+  SubscriptionError(this.id, this.payload) : super(MessageTypes.GQL_ERROR);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+    'id': id,
+    'payload': payload,
+  };
+}
+
+/// Server message to the client to indicate that no more data will be sent
+/// for a particular subscription instance.
+class SubscriptionComplete extends GraphQLSocketMessage {
+  final String id;
+
+  SubscriptionComplete(this.id) : super(MessageTypes.GQL_COMPLETE);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+    'id': id,
+  };
+}
+
+/// Not expected to be created. Indicates there are problems parsing the server
+/// response, or that new unsupported types have been added to the subscription
+/// implementation.
+class UnknownData extends GraphQLSocketMessage {
+  final dynamic payload;
+
+  UnknownData(this.payload) : super(MessageTypes.GQL_UNKNOWN);
+
+  @override
+  dynamic toJson() => {
+    'type': type,
+    'payload': payload,
+  };
+}

--- a/lib/src/websocket/socket.dart
+++ b/lib/src/websocket/socket.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import '../../graphql_flutter.dart';
+
+/// Wraps a standard web socket instance to marshal and un-marshal the server /
+/// client payloads into dart object representation.
+class GraphQLSocket {
+  final StreamController<GraphQLSocketMessage> _subject =
+      StreamController.broadcast<GraphQLSocketMessage>();
+
+  final WebSocket _socket;
+
+  GraphQLSocket(this._socket) {
+    _socket.map((message) => json.decode(message)).listen((message) {
+      final dynamic type = message['type'] ?? 'unknown';
+      final dynamic payload = message['payload'] ?? {};
+      final dynamic id = message['id'] ?? 'none';
+
+      if (type == MessageTypes.GQL_CONNECTION_ACK) {
+        _subject.add(ConnectionAck());
+      } else if (type == MessageTypes.GQL_CONNECTION_ERROR) {
+        _subject.add(ConnectionError(payload));
+      } else if (type == MessageTypes.GQL_DATA) {
+        final dynamic data = payload['data'] ?? null;
+        final dynamic errors = payload['errors'] ?? null;
+        _subject.add(SubscriptionData(id, data, errors));
+      } else if (type == MessageTypes.GQL_ERROR) {
+        _subject.add(SubscriptionError(id, payload));
+      } else if (type == MessageTypes.GQL_COMPLETE) {
+        _subject.add(SubscriptionComplete(id));
+      } else {
+        _subject.add(UnknownData(message));
+      }
+    });
+  }
+
+  void write(final GraphQLSocketMessage message) {
+    _socket.add(json.encode(message, toEncodable: (m) => m.toJson()));
+  }
+
+  Stream<ConnectionAck> get connectionAck => _subject.stream
+      .where((message) => message is ConnectionAck)
+      .cast<ConnectionAck>();
+
+  Stream<ConnectionError> get connectionError => _subject.stream
+      .where((message) => message is ConnectionError)
+      .cast<ConnectionError>();
+
+  Stream<UnknownData> get unknownData => _subject.stream
+      .where((message) => message is UnknownData)
+      .cast<UnknownData>();
+
+  Stream<SubscriptionData> get subscriptionData => _subject.stream
+      .where((message) => message is SubscriptionData)
+      .cast<SubscriptionData>();
+
+  Stream<SubscriptionError> get subscriptionError => _subject.stream
+      .where((message) => message is SubscriptionError)
+      .cast<SubscriptionError>();
+
+  Stream<SubscriptionComplete> get subscriptionComplete => _subject.stream
+      .where((message) => message is SubscriptionComplete)
+      .cast<SubscriptionComplete>();
+}

--- a/lib/src/widgets/subscription.dart
+++ b/lib/src/widgets/subscription.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import '../websocket/messages.dart';
+import '../socket_client.dart';
+
+typedef OnSubscriptionCompleted = void Function();
+
+typedef SubscriptionBuilder = Widget Function({
+  final bool loading,
+  final dynamic payload,
+  final dynamic error,
+});
+
+class Subscription extends StatefulWidget {
+  final String operationName;
+  final String query;
+  final dynamic variables;
+  final SubscriptionBuilder builder;
+  final OnSubscriptionCompleted onCompleted;
+  final dynamic initial;
+
+  Subscription(
+    this.operationName,
+    this.query, {
+    this.variables = const { },
+    final Key key,
+    @required this.builder,
+    this.initial,
+    this.onCompleted,
+  }) : super(key: key);
+
+  @override
+  _SubscriptionState createState() => _SubscriptionState();
+}
+
+class _SubscriptionState extends State<Subscription> {
+  bool _loading = true;
+  dynamic _data;
+  dynamic _error;
+
+  bool _alive = true;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final Stream<SubscriptionData> stream = socketClient.subscribe(
+        SubscriptionRequest(
+            widget.operationName,
+            widget.query,
+            widget.variables
+        ));
+
+    stream.takeWhile((message) => this._alive).listen(
+      _onData,
+      onError: _onError,
+      onDone: _onDone,
+    );
+
+    if (widget.initial != null) {
+      setState(() {
+        _loading = true;
+        _data = widget.initial;
+        _error = null;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _alive = false;
+    super.dispose();
+  }
+
+  void _onData(final SubscriptionData message) {
+    setState(() {
+      _loading = false;
+      _data = message.data;
+      _error = message.errors;
+    });
+  }
+
+  void _onError(final Object error) {
+    setState(() {
+      _loading = false;
+      _data = null;
+      _error = (error is SubscriptionError) ? error.payload : error;
+    });
+  }
+
+  void _onDone() {
+    if (widget.onCompleted != null) {
+      widget.onCompleted();
+    }
+  }
+
+  Widget build(final BuildContext context) {
+    return widget.builder(
+      loading: _loading,
+      error: _error,
+      payload: _data,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   http: ^0.11.0
   path_provider: ^0.4.0
   test: ^0.12.0
+  uuid: 1.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi Everyone, 

Just want to start off by saying thanks! I think this is an awesome project and am excited to see it grow! For my personal project I need to use GraphQL subscriptions, so I figured I'd try my hand at a proof of concept. When you get some time take a look and let me know if it's in line with how you see Subscriptions working in this project. As an FYI I'm new to dart programming and my style is closer to Java development.. all nitpicks are welcome! :)

I implemented the subscriptions by following this guide from [apollographql/subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md). ~~This work does not yet contain any flutter `Widget` classes, it's just the implementation of the websocket client.~~

Because a lot of the parameters for the `http` and `ws` endpoints can vary pretty heavily, I decided to implement a separate `socket_client` instead of merging it with the existing http `client`. I also chose to wrap the data types being sent over the wire as concrete dart classes as opposed to just using `dynamic`. Not sure if this is the best solution as translating from dart object to json and vice versa doesn't seem to be totally trivial in dart... that said you do get better compile time safety from it. I chose to also implement this solution using the basic `Stream` api, but I feel we might get a lot of benefit from introducing `rxdart` into the project. 

I ran the following command-line program against my graphql server running on graphql-dotnet. I don't believe the github api has any available subscription api's to use in the example program. It might be interesting to host a dedicated server somewhere for handling development requests.

```dart
main() {
  _main();
}

_main() async {
  socketClient = await SocketClient.connect('ws://192.168.1.102:55855/graphql');

  var operationName = "SessionAudioEvent";
  var query = """subscription $operationName(\$sessionId: String!) {
    sessionAudioEvent(sessionId: \$sessionId) {
      audio {
        volume
      }
    }
  }""";
  var variables = {'sessionId': '5aae762d-cb4d-e909-7424-32251326e18b'};

  socketClient.subscribe(SubscriptionRequest(operationName, query, variables))
      .listen(print);
}
```

Prints the following:

```text
{type: connection_ack}
{type: data, data: {sessionAudioEvent: {audio: {volume: 0.8765849471092224}}}, errors: {}}
{type: data, data: {sessionAudioEvent: {audio: {volume: 0.6523423194885254}}}, errors: {}}
{type: data, data: {sessionAudioEvent: {audio: {volume: 0.38732823729515076}}}, errors: {}}
```

**Update:**

Following the implementation of the `Mutation` widget, I was able to implement a `Subscription` widget. One of the tougher parts of creating this widget is making sure that the subscription object is only constructed once. To do this I override the `initState` and `dispose` methods on the widget `State` class. With the following modification to the example project `main.dart` file (and the constructs created in the above example) I was able to implement a real-time `Widget`:

```dart 

class _MyHomePageState extends State<MyHomePage> {
  @override
  Widget build(BuildContext context) {
    return new Scaffold(
      body: new Center(
        child: new Subscription(SubscriptionRequest(operationName, query, variables),
          builder: ({bool loading, SubscriptionData payload, SubscriptionError error}) {
            if (payload?.data != null) {
              var volume = payload.data['sessionAudioEvent']['audio']['volume'] ?? 0.0;
              return new Slider(value: volume, onChanged: (v) {});
            } else {
              return new Slider(value: 0.0, onChanged: (v) {});
            }
          }
        ),
      )
    );
  }
}
```

