### PR TITLE
add error extensions support

### DIFF
--- a/graphql.iml
+++ b/graphql.iml
@@ -9,11 +9,14 @@
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/example/build" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 25 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/lib/graphql_flutter.dart
+++ b/lib/graphql_flutter.dart
@@ -14,3 +14,5 @@ export 'package:graphql_flutter/src/widgets/graphql_consumer.dart';
 export 'package:graphql_flutter/src/widgets/query.dart';
 export 'package:graphql_flutter/src/widgets/mutation.dart';
 export 'package:graphql_flutter/src/widgets/subscription.dart';
+
+export 'package:graphql_flutter/src/exceptions.dart';

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -25,7 +25,8 @@ class GQLError {
 
   /// The path of the field in error.
   final List<dynamic> path;
-  
+
+  /// Custom error data returned by your GraphQL API server
   final Map<String, dynamic> extensions;
 
   /// Constructs a [GQLError] from a JSON map.

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -25,13 +25,16 @@ class GQLError {
 
   /// The path of the field in error.
   final List<dynamic> path;
+  
+  final Map<String, dynamic> extensions;
 
   /// Constructs a [GQLError] from a JSON map.
   GQLError.fromJSON(Map data)
       : message = data['message'],
         locations = new List.from(
             (data['locations']).map((d) => new Location.fromJSON(d))),
-        path = data['path'];
+        path = data['path'],
+        extensions = data['extensions'];
 
   @override
   String toString() =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,4 +19,4 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.0.0-dev.52.0"
+  sdk: ">=2.0.0-dev.52.0 <3.0.0"


### PR DESCRIPTION
Fixes #61 . See Apollo documentation on custom error responses: https://www.apollographql.com/docs/apollo-server/v2/features/errors.html

also, export exceptions file. host applications can't effectively catch errors if they can't see the
types.