### PR TITLE
Move test dependency to the dev section

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,12 @@ dependencies:
   http: ^0.11.0
   path_provider: ^0.4.0
   uuid: ^1.0.0
-  test: ^0.12.0
+
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  test: ^0.12.0
 
 environment:
   sdk: ">=2.0.0-dev.52.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   path_provider: ^0.4.0
   uuid: ^1.0.0
 
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
I believe to not be necessary to have flutter test in the dependency section and it is currently preventing this package to be used in the latest version of flutter since the SDK depends on test 1.3