### PR TITLE
Added optional parameter `initPayload`

### DIFF
--- a/lib/src/socket_client.dart
+++ b/lib/src/socket_client.dart
@@ -16,22 +16,26 @@ class SocketClient {
     final Map<String, String> headers = const {
       'content-type': 'application/json',
     },
+    final Map<String, String> initPayload
   }) async {
+    _initPayload = initPayload;
+
     return SocketClient(GraphQLSocket(await WebSocket.connect(
       endPoint,
       protocols: protocols,
-      headers: headers,
+      headers: headers
     )));
   }
 
   final Uuid _uuid = Uuid();
   final GraphQLSocket _socket;
+  static Map<String, String> _initPayload;
 
   SocketClient(this._socket) {
     _socket.connectionAck.listen(print);
     _socket.connectionError.listen(print);
     _socket.unknownData.listen(print);
-    _socket.write(InitOperation());
+    _socket.write(InitOperation(_initPayload));
   }
 
   Stream<SubscriptionData> subscribe(final SubscriptionRequest payload) {

--- a/lib/src/websocket/messages.dart
+++ b/lib/src/websocket/messages.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// These messages represent the structures used for Client-server communication
 /// in a GraphQL web-socket subscription. Each message is represented in a JSON
 /// format where the data type is denoted by the `type` field.
@@ -45,12 +47,22 @@ abstract class GraphQLSocketMessage extends JsonSerializable {
 /// send this message to tell the server that it is ready to begin sending
 /// new subscription queries.
 class InitOperation extends GraphQLSocketMessage {
-  InitOperation() : super(MessageTypes.GQL_CONNECTION_INIT);
+  final Map<String, String> payload;
+
+  InitOperation(this.payload) : super(MessageTypes.GQL_CONNECTION_INIT);
 
   @override
-  dynamic toJson() => {
-        'type': type,
-      };
+  dynamic toJson() {
+    final Map<String, String> jsonMap = new Map();
+    jsonMap['type'] = type;
+
+    if (this.payload != null) {
+      jsonMap['payload'] = json.encode(this.payload);
+    }
+
+    return  json.encode(jsonMap);
+
+  }
 }
 
 /// Represent the payload used during a Start query operation.


### PR DESCRIPTION
This PR adds the optional parameter to the static `connect` function. initPayload is a type of `Map<String, String>`, which will then be converted to JSON format. As specified by Apollo Client and required subscription authorisation, we could then simply do:

```
  Map<String, String> initPayload = new Map();
  initPayload['accessToken'] = Auth.accessToken;

    await SocketClient.connect(
      Static.BASE_URL_GRAPHQL_SUB,
      initPayload: initPayload
    )
    .then((createdClient) {
      client = createdClient;
      connections[operationName] = client;
    });
```

That being used, `connection_init` should now send the payload with `accessToken` to the websocket stream.

Resolves: https://github.com/zino-app/graphql-flutter/issues/74