### PR TITLE
Patch 11

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,6 +62,12 @@ class _MyHomePageState extends State<MyHomePage> {
         options: QueryOptions(
           document: queries.readRepositories,
           pollInterval: 4,
+          // you can optionally override some http options through the contexts
+          context: <String, dynamic>{
+            'headers': <String, String>{
+              'Authorization': 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
+            },
+          },
         ),
         builder: (QueryResult result) {
           if (result.errors != null) {
@@ -72,13 +78,13 @@ class _MyHomePageState extends State<MyHomePage> {
             return Text('Loading');
           }
 
-          // it can be either Map or List
+          // result.data can be either a Map or a List
           List repositories = result.data['viewer']['repositories']['nodes'];
 
           return ListView.builder(
             itemCount: repositories.length,
             itemBuilder: (context, index) {
-              final repository = repositories[index];
+              final Map<String, dynamic> repository = repositories[index];
 
               return Mutation(
                 options: MutationOptions(
@@ -88,19 +94,19 @@ class _MyHomePageState extends State<MyHomePage> {
                   RunMutation addStar,
                   QueryResult result,
                 ) {
-                  if (result.data != null && result.data.isNotEmpty) {
+                  if (result.data != null && (result.data as Map).isNotEmpty) {
                     repository['viewerHasStarred'] =
                         result.data['addStar']['starrable']['viewerHasStarred'];
                   }
 
                   return ListTile(
-                    leading: repository['viewerHasStarred']
+                    leading: (repository['viewerHasStarred'] as bool)
                         ? const Icon(Icons.star, color: Colors.amber)
                         : const Icon(Icons.star_border),
-                    title: Text(repository['name']),
-                    // NOTE: optimistic ui updates are not implemented yet, therefore changes may take upto 1 second to show.
+                    title: Text(repository['name'] as String),
+                    // optimistic ui updates are not implemented yet, therefore changes may take some time to show
                     onTap: () {
-                      addStar({
+                      addStar(<String, dynamic>{
                         'starrableId': repository['id'],
                       });
                     },

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -44,7 +44,7 @@ class HttpLink extends Link {
                 ),
                 options: context['fetchOptions'] as Map<String, dynamic>,
                 credentials: context['credentials'] as Map<String, dynamic>,
-                headers: context['credentials'] as Map<String, String>,
+                headers: context['headers'] as Map<String, String>,
               );
             }
 


### PR DESCRIPTION
This PR patches a small bug in the http link and improves the example.

### Breaking changes

n/a

#### Fixes / Enhancements

- Fixed a bug where the wrong key was selected from the context map.

#### Docs

- Added an example of optionally overriding http options trough the context.
- Updated the example with explicit type casting.
