### PR TITLE
Implement the onComplete callback for the Mutation widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -86,11 +86,12 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
                 builder: (
                   RunMutation addStar,
-                  QueryResult result,
+                  QueryResult addStarResult,
                 ) {
-                  if (result.data != null && result.data.isNotEmpty) {
-                    repository['viewerHasStarred'] =
-                        result.data['addStar']['starrable']['viewerHasStarred'];
+                  if (addStarResult.data != null &&
+                      addStarResult.data.isNotEmpty) {
+                    repository['viewerHasStarred'] = addStarResult
+                        .data['addStar']['starrable']['viewerHasStarred'];
                   }
 
                   return ListTile(
@@ -106,24 +107,24 @@ class _MyHomePageState extends State<MyHomePage> {
                     },
                   );
                 },
-                // onCompleted: (Map<String, dynamic> data) {
-                //   showDialog(
-                //     context: context,
-                //     builder: (BuildContext context) {
-                //       return AlertDialog(
-                //         title: Text('Thanks for your star!'),
-                //         actions: <Widget>[
-                //           SimpleDialogOption(
-                //             child: Text('Dismiss'),
-                //             onPressed: () {
-                //               Navigator.of(context).pop();
-                //             },
-                //           )
-                //         ],
-                //       );
-                //     },
-                //   );
-                // },
+                onCompleted: (QueryResult onCompleteResult) {
+                  showDialog(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: Text('Thanks for your star!'),
+                        actions: <Widget>[
+                          SimpleDialogOption(
+                            child: Text('Dismiss'),
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
+                          )
+                        ],
+                      );
+                    },
+                  );
+                },
               );
             },
           );

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -34,7 +34,7 @@ class QueryState extends State<Query> {
 
   @override
   void dispose() {
-    observableQuery.close();
+    observableQuery?.close();
     super.dispose();
   }
 
@@ -74,10 +74,10 @@ class QueryState extends State<Query> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
-      stream: observableQuery.stream,
       initialData: QueryResult(
         loading: true,
       ),
+      stream: observableQuery.stream,
       builder: (
         BuildContext buildContext,
         AsyncSnapshot<QueryResult> snapshot,


### PR DESCRIPTION
This PR implements the onComplete callback for  the `Mutation` widget. It also adds some extra safety when tearing down an `ObservableQuery`.

### Breaking changes

n/a

#### Fixes / Enhancements

- Fixed a scenario where the dispose method was calling `close` on the observableQuery but might not have been initialised.
- Added the onComplete callback for  the `Mutation` widget.

#### Docs

- Updated the `Mutation` example with the new onComplete callback.