### PR TITLE
🔧 Fixed a bug where getQueryResult was called before client cloud init

### DIFF
--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -47,8 +47,6 @@ class QueryState extends State<Query> {
     if (widget.pollInterval is int) {
       pollInterval = Duration(seconds: widget.pollInterval);
     }
-
-    getQueryResult();
   }
 
   @override


### PR DESCRIPTION
This PR fixes #75.

### Breaking changes

n/a

#### Fixes / Enhancements

-  Fixed a bug where getQueryResult was called before client cloud init. @HofmannZ

#### Docs

n/a