### PR TITLE
Patch 13

### DIFF
--- a/lib/src/core/graphql_error.dart
+++ b/lib/src/core/graphql_error.dart
@@ -30,7 +30,7 @@ class GraphQLError {
   final Map<String, dynamic> extensions;
 
   /// Constructs a [GraphQLError] from a JSON map.
-  GraphQLError.fromJSON(Map<String, dynamic> data)
+  GraphQLError.fromJSON(dynamic data)
       : message = data['message'],
         locations = data['locations'] is List<Map<String, int>>
             ? List<Location>.from(

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -64,6 +64,8 @@ class QueryManager {
     BaseOptions options,
   ) async {
     final ObservableQuery observableQuery = getQuery(queryId);
+    // XXX there is a bug in the `graphql_parser` package, where this result might be
+    // null event though the operation name is present in the document
     final String operationName = getOperationName(options.document);
     // create a new operation to fetch
     final Operation operation = Operation(
@@ -134,8 +136,8 @@ class QueryManager {
 
     queryResult = _mapFetchResultToQueryResult(fetchResult);
 
-    // add the result to an observable query if it exists
-    if (observableQuery != null) {
+    // add the result to an observable query if it exists and not closed
+    if (observableQuery != null && !observableQuery.controller.isClosed) {
       observableQuery.controller.add(queryResult);
     }
 

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -169,7 +169,7 @@ class QueryManager {
 
     if (fetchResult.errors != null) {
       errors = List<GraphQLError>.from(fetchResult.errors.map<GraphQLError>(
-        (Map<String, dynamic> rawError) => GraphQLError.fromJSON(rawError),
+        (dynamic rawError) => GraphQLError.fromJSON(rawError),
       ));
     }
 

--- a/lib/src/core/query_options.dart
+++ b/lib/src/core/query_options.dart
@@ -150,6 +150,18 @@ class WatchQueryOptions extends QueryOptions {
     Map<String, dynamic> a,
     Map<String, dynamic> b,
   ) {
+    if (a == null && b == null) {
+      return false;
+    }
+
+    if (a == null && b != null) {
+      return true;
+    }
+
+    if (a != null && b == null) {
+      return true;
+    }
+
     if (a.length != b.length) {
       return true;
     }
@@ -157,7 +169,7 @@ class WatchQueryOptions extends QueryOptions {
     bool areDifferent = false;
 
     a.forEach((String key, dynamic value) {
-      if ((!b.containsKey(key)) || b[key] != a[key]) {
+      if ((!b.containsKey(key)) || b[key] != value) {
         areDifferent = true;
       }
     });

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -1,7 +1,8 @@
 import 'package:graphql_flutter/src/core/graphql_error.dart';
 
 class QueryResult {
-  dynamic data; // List<Map<String, dynamic>> or Map<String, dynamic>
+  /// List<dynamic> or Map<String, dynamic>
+  dynamic data;
   List<GraphQLError> errors;
   bool loading;
   bool stale;
@@ -12,4 +13,12 @@ class QueryResult {
     this.loading,
     this.stale,
   });
+
+  bool get hasErrors {
+    if (errors == null) {
+      return false;
+    }
+
+    return errors.isEmpty;
+  }
 }

--- a/lib/src/link/fetch_result.dart
+++ b/lib/src/link/fetch_result.dart
@@ -1,6 +1,8 @@
 class FetchResult {
-  List<Map<String, dynamic>> errors;
-  dynamic data; // List<Map<String, dynamic>> or Map<String, dynamic>
+  List<dynamic> errors;
+
+  /// List<dynamic> or Map<String, dynamic>
+  dynamic data;
   Map<String, dynamic> extensions;
   Map<String, dynamic> context;
 

--- a/lib/src/utilities/get_from_ast.dart
+++ b/lib/src/utilities/get_from_ast.dart
@@ -12,14 +12,12 @@ String getOperationName(String rawDoc) {
   // Parse the GraphQL document using recursive descent
   final DocumentContext doc = parser.parseDocument();
 
-  if (doc.definitions != null) {
+  if (doc.definitions != null && doc.definitions.isNotEmpty) {
     final OperationDefinitionContext definition = doc.definitions[0];
 
     if (definition != null) {
       if (definition.name != null) {
-        return definition.name.runtimeType == OperationDefinitionContext
-            ? definition.name
-            : null;
+        return definition.name;
       }
     }
   }

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -48,7 +48,7 @@ class MutationState extends State<Mutation> {
       });
     }
 
-    observableQuery.schedule();
+    observableQuery.fetchResults();
   }
 
   @override

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -39,15 +39,22 @@ class QueryState extends State<Query> {
   }
 
   @override
-  void didChangeDependencies() {
+  void didChangeDependencies() async {
     /// Gets the client from the closest wrapping [GraphQLProvider].
     client = GraphQLProvider.of(context).value;
     assert(client != null);
 
+    // override the default [QueryOptions] fetchPolicy.
+    FetchPolicy fetchPolicy = widget.options.fetchPolicy;
+
+    if (fetchPolicy == FetchPolicy.cacheFirst) {
+      fetchPolicy = FetchPolicy.cacheAndNetwork;
+    }
+
     final WatchQueryOptions options = WatchQueryOptions(
       document: widget.options.document,
       variables: widget.options.variables,
-      fetchPolicy: widget.options.fetchPolicy,
+      fetchPolicy: fetchPolicy,
       errorPolicy: widget.options.errorPolicy,
       pollInterval: widget.options.pollInterval,
       fetchResults: true,
@@ -61,7 +68,7 @@ class QueryState extends State<Query> {
         shouldCreateNewObservable = false;
       }
 
-      observableQuery.close();
+      await observableQuery.close();
     }
 
     if (shouldCreateNewObservable) {
@@ -82,7 +89,7 @@ class QueryState extends State<Query> {
         BuildContext buildContext,
         AsyncSnapshot<QueryResult> snapshot,
       ) {
-        return widget.builder(snapshot.data);
+        return widget?.builder(snapshot.data);
       },
     );
   }


### PR DESCRIPTION
### Breaking changes

n/a

#### Fixes / Enhancements

- Fixed a bug where getting the operation name was always returning null. @HofmannZ
- Override the fetch policy if the default query option is used. @HofmannZ
- Split up fetching and polling in the observable query. @HofmannZ
- Check if the stream is closed, before adding a new event to it. @HofmannZ
- Check if the variables have actully changed form or to null. @HofmannZ
- Added a new getter to check if a query result has errors. @HofmannZ
- Refactored the scheduler to only handle polling queries. @HofmannZ
- Updated the mutation widget to use the new api in observable query. @HofmannZ
- Resolve type cast exception when handling GraphQL errors @kolja-esders @HofmannZ

#### Docs

n/a