### PR TITLE
Resolve type cast exception when handling GraphQL errors

### DIFF
--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -201,7 +201,7 @@ FetchResult _parseResponse(Response response) {
   final FetchResult fetchResult = FetchResult();
 
   if (jsonResponse['errors'] != null) {
-    fetchResult.errors = jsonResponse['errors'];
+    fetchResult.errors = jsonResponse['errors'].cast<Map<String, dynamic>>() as List<Map<String, dynamic>>;
   }
 
   if (jsonResponse['data'] != null) {


### PR DESCRIPTION
#### Fixes / Enhancements

When sending a GraphQL query/mutation which leads to GraphQL errors (e.g. incorrect password during login mutation) the following exception occurs:

```
E/flutter ( 1260): [ERROR:flutter/shell/common/shell.cc(181)] Dart Error: Unhandled exception:
E/flutter ( 1260): type 'List<dynamic>' is not a subtype of type 'List<Map<String, dynamic>>'
E/flutter ( 1260): #0      QueryManager.fetchQuery (package:graphql_flutter/src/core/query_manager.dart:113:19)
E/flutter ( 1260): <asynchronous suspension>
E/flutter ( 1260): #1      QueryManager.mutate (package:graphql_flutter/src/core/query_manager.dart:59:12)
E/flutter ( 1260): #2      GraphQLClient.mutate (package:graphql_flutter/src/graphql_client.dart:44:25)
E/flutter ( 1260): #3      MyApp.build (file:///Users/kolja/Projects/graphql-flutter/example/lib/main.dart:27:18)
E/flutter ( 1260): #4      StatelessElement.build (package:flutter/src/widgets/framework.dart:3707:28)
E/flutter ( 1260): #5      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:3654:15)
E/flutter ( 1260): #6      Element.rebuild (package:flutter/src/widgets/framework.dart:3507:5)
E/flutter ( 1260): #7      ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:3634:5)
E/flutter ( 1260): #8      ComponentElement.mount (package:flutter/src/widgets/framework.dart:3629:5)
E/flutter ( 1260): #9      Element.inflateWidget (package:flutter/src/widgets/framework.dart:2919:14)
E/flutter ( 1260): #10     Element.updateChild (package:flutter/src/widgets/framework.dart:2722:12)
E/flutter ( 1260): #11     RenderObjectToWidgetElement._rebuild (package:flutter/src/widgets/binding.dart:881:16)
E/flutter ( 1260): #12     RenderObjectToWidgetElement.mount (package:flutter/src/widgets/binding.dart:852:5)
E/flutter ( 1260): #13     RenderObjectToWidgetAdapter.attachToRenderTree.<anonymous closure> (package:flutter/src/widgets/binding.dart:798:17)
E/flutter ( 1260): #14     BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2235:19)
E/flutter ( 1260): #15     RenderObjectToWidgetAdapter.attachToRenderTree (package:flutter/src/widgets/binding.dart:797:13)
E/flutter ( 1260): #16     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding&PaintingBinding&SemanticsBinding&RendererBinding&WidgetsBinding.attachRootWidget (package:flutter/src/widgets/binding.dart:689:7)
E/flutter ( 1260): #17     runApp (package:flutter/src/widgets/binding.dart:728:7)
E/flutter ( 1260): #18     main (file:///Users/kolja/Projects/graphql-flutter/example/lib/main.dart:8:16)
E/flutter ( 1260): #19     _startIsolate.<anonymous closure> (dart:isolate/runtime/libisolate_patch.dart:289:19)
E/flutter ( 1260): #20     _RawReceivePortImpl._handleMessage (dart:isolate/runtime/libisolate_patch.dart:171:12)
```

This PR aims to resolve the type cast issue. I'm not really a Dart expert so please feel free to propose a more thoughtful solution for this issue.