### PR TITLE
Propagate GraphQL errors to caller instead of throwing network exception

### DIFF
--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -124,7 +124,7 @@ class QueryManager {
       );
     }
 
-    if (fetchResult.data == null &&
+    if (fetchResult.data == null && fetchResult.errors == null &&
         (options.fetchPolicy == FetchPolicy.noCache ||
             options.fetchPolicy == FetchPolicy.networkOnly)) {
       throw Exception(


### PR DESCRIPTION
#### Fixes / Enhancements

Currently, GraphQL errors are not propagated back to the caller as part of the `QueryResult`.

Instead, a network exception is thrown beforehand since there is no valid data in the `FetchResult`. I would assume expected behavior is to not throw a network exception but instead let the user handle the domain-specific GraphQL errors by returning a `QueryResult` where `data == null` but `errors` are populated.