### PR TITLE
🔧 Fix connectivity errors not being thown on and streamed

### DIFF
--- a/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>

--- a/lib/src/core/graphql_error.dart
+++ b/lib/src/core/graphql_error.dart
@@ -29,6 +29,13 @@ class GraphQLError {
   /// Custom error data returned by your GraphQL API server
   final Map<String, dynamic> extensions;
 
+  GraphQLError({
+    this.message,
+    this.locations,
+    this.path,
+    this.extensions,
+  });
+
   /// Constructs a [GraphQLError] from a JSON map.
   GraphQLError.fromJSON(dynamic data)
       : message = data['message'],
@@ -44,5 +51,5 @@ class GraphQLError {
 
   @override
   String toString() =>
-      '$message: ${locations is List ? locations.map((Location l) => '[${l.toString()}]').join('') : ""}';
+      '$message: ${locations is List ? locations.map((Location l) => '[${l.toString()}]').join('') : "Undefind location"}';
 }

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -76,7 +76,6 @@ class QueryManager {
 
     FetchResult fetchResult;
     QueryResult queryResult;
-    Exception exception;
 
     if (options.context != null) {
       operation.setContext(options.context);

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -19,6 +19,14 @@ class QueryResult {
       return false;
     }
 
-    return errors.isEmpty;
+    return errors.isNotEmpty;
+  }
+
+  void addError(GraphQLError graphQLError) {
+    if (errors != null) {
+      errors.add(graphQLError);
+    } else {
+      errors = <GraphQLError>[graphQLError];
+    }
   }
 }

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -42,6 +42,8 @@ class QueryState extends State<Query> {
 
   @override
   void didChangeDependencies() async {
+    print('didChangeDependencies');
+
     /// Gets the client from the closest wrapping [GraphQLProvider].
     client = GraphQLProvider.of(context).value;
     assert(client != null);

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -42,8 +42,6 @@ class QueryState extends State<Query> {
 
   @override
   void didChangeDependencies() async {
-    print('didChangeDependencies');
-
     /// Gets the client from the closest wrapping [GraphQLProvider].
     client = GraphQLProvider.of(context).value;
     assert(client != null);


### PR DESCRIPTION
Server errors were being swallowed when the fetch initialised from an observable query. Therefore it was not possible to act upon those errors in the UI, as indicated in issue #105.

This PR adds errors that occur during data fetching to the observable query's stream.

### Breaking changes

n/a

#### Fixes / Enhancements

- Fixed connectivity errors not being thrown and streamed. @HofmannZ

#### Docs

n/a