### PR TITLE
Fix Query variable change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.vscode/
 .idea/libraries/
 .idea/workspace.xml
 .idea/tasks.xml

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,11 +54,11 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int numberOfRepos = 50;
+  int nRepositories = 50;
 
   void changeQuery(String number) {
     setState(() {
-      numberOfRepos = int.parse(number) ?? 50;
+      nRepositories = int.parse(number) ?? 50;
     });
   }
 
@@ -69,7 +69,7 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(widget.title),
       ),
       body: Container(
-        padding: const EdgeInsets.fromLTRB(8.0, 0.0, 8.0, 0.0),
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           mainAxisSize: MainAxisSize.max,
@@ -84,7 +84,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Query(
               options: QueryOptions(
                 document: queries.readRepositories,
-                variables: <String, dynamic>{'numberOfRepos': numberOfRepos},
+                variables: <String, dynamic>{'nRepositories': nRepositories},
                 pollInterval: 4,
                 // you can optionally override some http options through the contexts
                 //

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,8 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import './mutations/addStar.dart' as mutations;
 import './queries/readRepositories.dart' as queries;
 
+const String YOUR_PERSONAL_ACCESS_TOKEN = '<YOUR_PERSONAL_ACCESS_TOKEN_HERE>';
+
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
@@ -13,7 +15,7 @@ class MyApp extends StatelessWidget {
     final HttpLink link = HttpLink(
       uri: 'https://api.github.com/graphql',
       headers: <String, String>{
-        'Authorization': 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
+        'Authorization': 'Bearer $YOUR_PERSONAL_ACCESS_TOKEN',
       },
     );
 
@@ -52,94 +54,126 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  int numberOfRepos = 50;
+
+  void changeQuery(String number) {
+    setState(() {
+      numberOfRepos = int.parse(number) ?? 50;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
       ),
-      body: Query(
-        options: QueryOptions(
-          document: queries.readRepositories,
-          pollInterval: 4,
-          // you can optionally override some http options through the contexts
-          //
-          context: <String, dynamic>{
-            'headers': <String, String>{
-              'Authorization': 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
-            },
-          },
-        ),
-        builder: (QueryResult result) {
-          if (result.loading) {
-            return const CircularProgressIndicator();
-          }
-
-          if (result.hasErrors) {
-            return Text(result.errors.toString());
-          }
-
-          // result.data can be either a [List<dynamic>] or a [Map<String, dynamic>]
-          final List<dynamic> repositories =
-              result.data['viewer']['repositories']['nodes'];
-
-          return ListView.builder(
-            itemCount: repositories.length,
-            itemBuilder: (BuildContext context, int index) {
-              final Map<String, dynamic> repository = repositories[index];
-
-              return Mutation(
-                options: MutationOptions(
-                  document: mutations.addStar,
-                ),
-                builder: (
-                  RunMutation addStar,
-                  QueryResult addStarResult,
-                ) {
-                  if (addStarResult.data != null &&
-                      addStarResult.data.isNotEmpty) {
-                    repository['viewerHasStarred'] = addStarResult
-                        .data['addStar']['starrable']['viewerHasStarred'];
-                  }
-
-                  return ListTile(
-                    leading: repository['viewerHasStarred']
-                        ? const Icon(
-                            Icons.star,
-                            color: Colors.amber,
-                          )
-                        : const Icon(Icons.star_border),
-                    title: Text(repository['name']),
-                    onTap: () {
-                      // optimistic ui updates are not implemented yet, therefore changes may take some time to show
-                      addStar(<String, dynamic>{
-                        'starrableId': repository['id'],
-                      });
-                    },
-                  );
+      body: Container(
+        padding: const EdgeInsets.fromLTRB(8.0, 0.0, 8.0, 0.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          mainAxisSize: MainAxisSize.max,
+          children: <Widget>[
+            TextField(
+              decoration: const InputDecoration(
+                labelText: 'Number of repos (default 50)',
+              ),
+              keyboardType: TextInputType.number,
+              onSubmitted: changeQuery,
+            ),
+            Query(
+              options: QueryOptions(
+                document: queries.readRepositories,
+                variables: <String, dynamic>{'numberOfRepos': numberOfRepos},
+                pollInterval: 4,
+                // you can optionally override some http options through the contexts
+                //
+                context: <String, dynamic>{
+                  'headers': <String, String>{
+                    'Authorization': 'Bearer $YOUR_PERSONAL_ACCESS_TOKEN',
+                  },
                 },
-                onCompleted: (QueryResult onCompleteResult) {
-                  showDialog<AlertDialog>(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return AlertDialog(
-                        title: const Text('Thanks for your star!'),
-                        actions: <Widget>[
-                          SimpleDialogOption(
-                            child: const Text('Dismiss'),
-                            onPressed: () {
-                              Navigator.of(context).pop();
+              ),
+              builder: (QueryResult result) {
+                if (result.loading) {
+                  return Container(
+                    padding: const EdgeInsets.all(8.0),
+                    child: const CircularProgressIndicator(),
+                  );
+                }
+
+                if (result.hasErrors) {
+                  return Text('\nErrors: \n  ' + result.errors.join(',\n  '));
+                }
+
+                // result.data can be either a [List<dynamic>] or a [Map<String, dynamic>]
+                final List<dynamic> repositories =
+                    result.data['viewer']['repositories']['nodes'];
+
+                return Expanded(
+                  child: ListView.builder(
+                    itemCount: repositories.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      final Map<String, dynamic> repository =
+                          repositories[index];
+
+                      return Mutation(
+                        options: MutationOptions(
+                          document: mutations.addStar,
+                        ),
+                        builder: (
+                          RunMutation addStar,
+                          QueryResult addStarResult,
+                        ) {
+                          if (addStarResult.data != null &&
+                              addStarResult.data.isNotEmpty) {
+                            repository['viewerHasStarred'] =
+                                addStarResult.data['addStar']['starrable']
+                                    ['viewerHasStarred'];
+                          }
+
+                          return ListTile(
+                            leading: repository['viewerHasStarred']
+                                ? const Icon(
+                                    Icons.star,
+                                    color: Colors.amber,
+                                  )
+                                : const Icon(Icons.star_border),
+                            title: Text(repository['name']),
+                            onTap: () {
+                              // optimistic ui updates are not implemented yet, therefore changes may take some time to show
+                              addStar(<String, dynamic>{
+                                'starrableId': repository['id'],
+                              });
                             },
-                          )
-                        ],
+                          );
+                        },
+                        onCompleted: (QueryResult onCompleteResult) {
+                          showDialog<AlertDialog>(
+                            context: context,
+                            builder: (BuildContext context) {
+                              return AlertDialog(
+                                title: const Text('Thanks for your star!'),
+                                actions: <Widget>[
+                                  SimpleDialogOption(
+                                    child: const Text('Dismiss'),
+                                    onPressed: () {
+                                      Navigator.of(context).pop();
+                                    },
+                                  )
+                                ],
+                              );
+                            },
+                          );
+                        },
                       );
                     },
-                  );
-                },
-              );
-            },
-          );
-        },
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/example/lib/mutations/addStar.dart
+++ b/example/lib/mutations/addStar.dart
@@ -1,4 +1,4 @@
-final String addStar = '''
+const String addStar = '''
   mutation AddStar(\$starrableId: ID!) {
     addStar(input: {starrableId: \$starrableId}) {
       starrable {
@@ -6,5 +6,4 @@ final String addStar = '''
       }
     }
   }
-'''
-    .replaceAll('\n', ' ');
+''';

--- a/example/lib/queries/readRepositories.dart
+++ b/example/lib/queries/readRepositories.dart
@@ -1,7 +1,7 @@
-final String readRepositories = '''
-  query ReadRepositories {
+const String readRepositories = '''
+  query ReadRepositories(\$numberOfRepos: Int!) {
     viewer {
-      repositories(last: 50) {
+      repositories(last: \$numberOfRepos) {
         nodes {
           id
           name
@@ -10,5 +10,4 @@ final String readRepositories = '''
       }
     }
   }
-'''
-    .replaceAll('\n', ' ');
+''';

--- a/example/lib/queries/readRepositories.dart
+++ b/example/lib/queries/readRepositories.dart
@@ -1,7 +1,7 @@
 const String readRepositories = '''
-  query ReadRepositories(\$numberOfRepos: Int!) {
+  query ReadRepositories(\$nRepositories: Int!) {
     viewer {
-      repositories(last: \$numberOfRepos) {
+      repositories(last: \$nRepositories) {
         nodes {
           id
           name

--- a/lib/src/core/query_options.dart
+++ b/lib/src/core/query_options.dart
@@ -154,11 +154,7 @@ class WatchQueryOptions extends QueryOptions {
       return false;
     }
 
-    if (a == null && b != null) {
-      return true;
-    }
-
-    if (a != null && b == null) {
+    if (a == null || b == null) {
       return true;
     }
 

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -46,30 +46,25 @@ class QueryState extends State<Query> {
     );
   }
 
-  void query(WatchQueryOptions options) {
+  void _initQuery() {
     final GraphQLClient client = GraphQLProvider.of(context).value;
     assert(client != null);
-    observableQuery = client.watchQuery(options);
+    observableQuery?.close();
+    observableQuery = client.watchQuery(_options);
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    query(_options);
+    _initQuery();
   }
 
   @override
   void didUpdateWidget(Query oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    final WatchQueryOptions newOptions = _options;
-
-    final bool shouldCreateNewObservable =
-        !observableQuery.options.areEqualTo(newOptions);
-
-    if (shouldCreateNewObservable) {
-      observableQuery?.close();
-      query(newOptions);
+    if (!observableQuery.options.areEqualTo(_options)) {
+      _initQuery();
     }
   }
 


### PR DESCRIPTION
closes #103
The method we needed was `didUpdateWidget`, which is triggered by prop changes.
Still left in a `didChangeDependencies` query, which is called whenever `client` changes, as well as after `initState` for the initial query.

Also:
* added a variable input to the example to test the change
* removed the `.replaceAll('\n', ' ')` from operations, as graphql allows for `# comments` that mangle documents if joined