### PR TITLE
Change Mutation widget behavior

### DIFF
--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -50,6 +50,10 @@ class MutationState extends State<Mutation> {
       });
     }
 
+    observableQuery.controller.add(QueryResult(
+      loading: true,
+    ));
+
     observableQuery.fetchResults();
   }
 
@@ -101,7 +105,7 @@ class MutationState extends State<Mutation> {
   Widget build(BuildContext context) {
     return StreamBuilder<QueryResult>(
       initialData: QueryResult(
-        loading: true,
+        loading: false,
       ),
       stream: observableQuery.stream,
       builder: (


### PR DESCRIPTION
Make Mutation result initially return `loading=false`, and stream a `loading=true` just after `runMutation` is called.

This way we can rely on `result.loading` to, for instance, build a different widget while mutation loading.