### PR TITLE
🔧 fixed bug when set state was called after widget was unmounted

### DIFF
--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -80,11 +80,13 @@ class QueryState extends State<Query> {
         variables: widget.variables,
       );
 
-      setState(() {
-        data = result;
-        error = null;
-        loading = false;
-      });
+      if (this.mounted) {
+        setState(() {
+          data = result;
+          error = null;
+          loading = false;
+        });
+      }
     } catch (e) {
       // Ignore, right?
     }
@@ -95,17 +97,21 @@ class QueryState extends State<Query> {
         variables: widget.variables,
       );
 
-      setState(() {
-        data = result;
-        error = null;
-        loading = false;
-      });
-    } catch (e) {
-      if (data == {}) {
+      if (this.mounted) {
         setState(() {
-          error = e;
+          data = result;
+          error = null;
           loading = false;
         });
+      }
+    } catch (e) {
+      if (data == {}) {
+        if (this.mounted) {
+          setState(() {
+            error = e;
+            loading = false;
+          });
+        }
       }
     }
 


### PR DESCRIPTION
#### Fixes / Enhancements

- Fixed: Query Widget was calling set state after being unmounted ([https://docs.flutter.io/flutter/widgets/State/mounted.html]). 