### PR TITLE
Fix mutation calling onCompleted for loading state

### DIFF
--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -45,8 +45,10 @@ class MutationState extends State<Mutation> {
     if (widget.onCompleted != null) {
       onCompleteSubscription = observableQuery.stream.listen(
         (QueryResult result) {
-          widget.onCompleted(result);
-          onCompleteSubscription.cancel();
+          if (!result.loading) {
+            widget.onCompleted(result);
+            onCompleteSubscription.cancel();
+          }        
         },
       );
     }


### PR DESCRIPTION
After the introduction of the initial loading state to false on PR #112, the first emission of the observableQuery observable is a query result with the `loading: true`. 

The unexpected side effect of this change is that the `onCompleted` callback, which listens only to the first emission, would be called only for the loading state change and not for the query response itself.

This PR changes the `onCompleted` subscription to only call the method and cancel the subscription after the loading changes back to false.