### PR TITLE
Upgrade flutter_http version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.1.6
-  http: ^0.11.3+17
+  http: ^0.12.0
   http_parser: ^3.1.3
   path_provider: ^0.4.1
   uuid: ^1.0.3


### PR DESCRIPTION
On the dev channel, `flutter_http` must be version `0.12` or greater in
order to satisfy the `flutter_test` dependencies.

An example of the error follows.

---

== Error Message

Because every version of flutter_test from sdk depends on http 0.12.0 and graphql_flutter >=1.0.0-alpha.6 depends on http ^0.11.3+17, flutter_test from sdk is incompatible with graphql_flutter >=1.0.0-alpha.6.
So, because forums depends on both graphql_flutter ^1.0.0-alpha.10 and flutter_test any from sdk, version solving failed.