### PR TITLE
Add docs about using cilent without widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,31 @@ class MyApp extends StatelessWidget {
 ...
 ```
 
+### Using Client Without Widget
+
+You can using the GraphQL client directly to make queries or mutations without flutter widgets.
+
+```dart
+import 'dart:async';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+Client client = Client(
+    endPoint: 'https://api.github.com/graphql',
+    cache: InMemoryCache(),
+    apiToken: '<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>',
+);
+
+Future<Map<String, dynamic>> queryData() async {
+    Map<String, dynamic> data = await client.query(
+        readRepositories,
+        variables: {
+            'nRepositories': 50,
+        },
+    );
+    return data;
+}
+```
+
 ## Roadmap
 
 This is currently our roadmap, please feel free to request additions/changes.


### PR DESCRIPTION
It will be nice to add docs on how to use client directly without widgets. It is very useful when using it with ```FutureBuilder```'s ```future``` or ```RefreshIndicator```'s ```onRefresh``` of flutter.

#### Docs

- Added using client directly without flutter usage.
