### PR TITLE
Bugfix/subscription init payload

### DIFF
--- a/lib/src/websocket/messages.dart
+++ b/lib/src/websocket/messages.dart
@@ -57,10 +57,10 @@ class InitOperation extends GraphQLSocketMessage {
     jsonMap['type'] = type;
 
     if (payload != null) {
-      jsonMap['payload'] = json.encode(payload);
+      jsonMap['payload'] = payload;
     }
 
-    return json.encode(jsonMap);
+    return jsonMap;
   }
 }
 


### PR DESCRIPTION
Describe the purpose of the pull request.

### Breaking changes

Init payload was `json.encoded` which, in last iterations of alpha version of GraphQL, breaks subscriptions. Checking websocket connections, init payload has too many backslashes added to the quotes.

#### Fixes / Enhancements

Removed encoding from init `toJson` function
