### PR TITLE
Add refetch to QueryResult

### DIFF
--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -28,7 +28,10 @@ class ObservableQuery {
     );
   }
 
-  Stream<QueryResult> get stream => controller.stream;
+  Stream<QueryResult> get stream => controller.stream.map((QueryResult result) {
+        result.refetch = fetchResults;
+        return result;
+      });
 
   void onListen() {
     if (options.fetchResults) {
@@ -36,12 +39,15 @@ class ObservableQuery {
     }
   }
 
-  void fetchResults() {
-    queryManager.fetchQuery(queryId, options);
+  Future<QueryResult> fetchResults() {
+    final Future<QueryResult> result =
+        queryManager.fetchQuery(queryId, options);
 
     if (options.pollInterval != null) {
       startPolling(options.pollInterval);
     }
+
+    return result;
   }
 
   void startPolling(int pollInterval) {

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -6,12 +6,14 @@ class QueryResult {
   List<GraphQLError> errors;
   bool loading;
   bool stale;
+  void Function() refetch;
 
   QueryResult({
     this.data,
     this.errors,
     this.loading,
     this.stale,
+    this.refetch,
   });
 
   bool get hasErrors {

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -6,7 +6,7 @@ class QueryResult {
   List<GraphQLError> errors;
   bool loading;
   bool stale;
-  void Function() refetch;
+  Future<QueryResult> Function() refetch;
 
   QueryResult({
     this.data,

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -86,7 +86,13 @@ class QueryState extends State<Query> {
         BuildContext buildContext,
         AsyncSnapshot<QueryResult> snapshot,
       ) {
-        return widget?.builder(snapshot.data);
+        final QueryResult data = snapshot.data;
+        data.refetch = () async {
+          observableQuery.fetchResults();
+          await observableQuery.stream
+              .firstWhere((QueryResult result) => !result.loading);
+        };
+        return widget?.builder(data);
       },
     );
   }

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -86,13 +86,7 @@ class QueryState extends State<Query> {
         BuildContext buildContext,
         AsyncSnapshot<QueryResult> snapshot,
       ) {
-        final QueryResult data = snapshot.data;
-        data.refetch = () async {
-          observableQuery.fetchResults();
-          await observableQuery.stream
-              .firstWhere((QueryResult result) => !result.loading);
-        };
-        return widget?.builder(data);
+        return widget?.builder(snapshot.data);
       },
     );
   }


### PR DESCRIPTION
Adding a refetch function to QueryResult. Perhaps there's another better way that also can be easily implemented, but this seems to do the job for now.

### Breaking changes

No breaking changes.

#### Fixes / Enhancements

- Added `refetch` to QueryResult

#### Docs

None (yet).
