### PR TITLE
Add GraphQL message type `GQL_CONNECTION_KEEP_ALIVE`

### DIFF
--- a/lib/src/websocket/messages.dart
+++ b/lib/src/websocket/messages.dart
@@ -15,6 +15,7 @@ class MessageTypes {
   // server connections
   static const String GQL_CONNECTION_ACK = 'connection_ack';
   static const String GQL_CONNECTION_ERROR = 'connection_error';
+  static const String GQL_CONNECTION_KEEP_ALIVE = 'ka';
 
   // client operations
   static const String GQL_START = 'start';
@@ -138,6 +139,16 @@ class ConnectionError extends GraphQLSocketMessage {
   dynamic toJson() => <String, dynamic>{
         'type': type,
         'payload': payload,
+      };
+}
+
+/// The server will send this message to keep the connection alive
+class ConnectionKeepAlive extends GraphQLSocketMessage {
+  ConnectionKeepAlive(): super(MessageTypes.GQL_CONNECTION_KEEP_ALIVE);
+
+  @override
+  dynamic toJson() => <String, dynamic>{
+        'type': type,
       };
 }
 

--- a/lib/src/websocket/socket.dart
+++ b/lib/src/websocket/socket.dart
@@ -28,6 +28,9 @@ class GraphQLSocket {
           case MessageTypes.GQL_CONNECTION_ERROR:
             _subject.add(ConnectionError(payload));
             break;
+          case MessageTypes.GQL_CONNECTION_KEEP_ALIVE:
+            _subject.add(ConnectionKeepAlive());
+            break;
           case MessageTypes.GQL_DATA:
             final dynamic data = payload['data'];
             final dynamic errors = payload['errors'];
@@ -58,6 +61,10 @@ class GraphQLSocket {
   Stream<ConnectionAck> get connectionAck => _subject.stream
       .where((GraphQLSocketMessage message) => message is ConnectionAck)
       .cast<ConnectionAck>();
+
+  Stream<ConnectionKeepAlive> get connectionKeepAlive => _subject.stream
+      .where((GraphQLSocketMessage message) => message is ConnectionKeepAlive)
+      .cast<ConnectionKeepAlive>();
 
   Stream<ConnectionError> get connectionError => _subject.stream
       .where((GraphQLSocketMessage message) => message is ConnectionError)


### PR DESCRIPTION
Describe the purpose of the pull request.

#### Fixes / Enhancements

- Adds the GraphQL message type `GQL_CONNECTION_KEEP_ALIVE`, so it isn't interpreted as `UnknownData` anymore.

#### Docs

- Added `MessageType` constant `GQL_CONNECTION_KEEP_ALIVE`
- Added `GraphQLSocketMessage` class `ConnectionKeepAlive`
- Added `Stream<ConnectionKeepAlive>`  to `GraphQLSocket`
