### PR TITLE
export `QueryManager`

### DIFF
--- a/lib/graphql_flutter.dart
+++ b/lib/graphql_flutter.dart
@@ -6,6 +6,7 @@ export 'package:graphql_flutter/src/socket_client.dart';
 export 'package:graphql_flutter/src/core/query_options.dart';
 export 'package:graphql_flutter/src/core/query_result.dart';
 export 'package:graphql_flutter/src/core/graphql_error.dart';
+export 'package:graphql_flutter/src/core/query_manager.dart';
 
 export 'package:graphql_flutter/src/link/link.dart';
 export 'package:graphql_flutter/src/link/http/link_http.dart';


### PR DESCRIPTION
`QueryManager` class is needed by end users to update the writable `queryManager` variable in `GraphQLClient`. An example includes: "Creating a Client at app start to wrap `MaterialApp`. If `HttpLink` headers Authorization token is not known at startup, it can be updated later."

Describe the purpose of the pull request.

### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
