### PR TITLE
Fixe data.isEmpty instead of data == {}

### DIFF
--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -105,7 +105,7 @@ class QueryState extends State<Query> {
         });
       }
     } catch (e) {
-      if (data == {}) {
+      if (data.isEmpty) {
         if (this.mounted) {
           setState(() {
             error = e;


### PR DESCRIPTION
Describe the purpose of the pull request.



#### Fixes / Enhancements

- Fixed data == {} was always false, instead of data.isEmpty

Test Example:
```
Map<String, dynamic> data = {};
    if (data == {}) {
      print('data == {}');
    } else {
      print('data != {}');
    }
    if (data.isEmpty) {
      print('data.isEmpty');
    } else {
      print('data.isNotEmpty');
    }
    data = {"a":{}};
    if (data == {}) {
      print('data == {}');
    } else {
      print('data != {}');
    }
    if (data.isEmpty) {
      print('data.isEmpty');
    } else {
      print('data.isNotEmpty');
    }
```
the console print is:
```
flutter: data != {}
flutter: data.isEmpty
flutter: data != {}
flutter: data.isNotEmpty

```

