### PR TITLE
Fix erroneous closing of observableQuery

### DIFF
--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -95,11 +95,10 @@ class MutationState extends State<Mutation> {
       if (observableQuery.options.areEqualTo(options)) {
         shouldCreateNewObservable = false;
       }
-
-      observableQuery.close();
     }
 
     if (shouldCreateNewObservable) {
+      observableQuery?.close();
       observableQuery = client.watchQuery(options);
     }
 


### PR DESCRIPTION
The previous code closed the `observableQuery` any time
`didChangeDependencies` was called, whether or not it was creating a new
one. This meant you could have a closed stream that events were added
to, which caused the following error:

```
flutter: Another exception was thrown: Bad state: Cannot add new events
after calling close
```

### Breaking changes

- None

#### Fixes / Enhancements

- Fixed calling `runMutation` multiple times on the same screen in the case where a rebuild was triggered on `Mutation` but no dependencies that it cared about were changed.
  - The error was `Bad state: Cannot add new events after calling close`