### PR TITLE
Fix cache updating subqueries that does not have typename

### DIFF
--- a/lib/src/cache/in_memory.dart
+++ b/lib/src/cache/in_memory.dart
@@ -2,10 +2,24 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
-
 import 'package:path_provider/path_provider.dart';
-
 import 'package:graphql_flutter/src/cache/cache.dart';
+
+void _recursiveAddAll(
+  Map<String, dynamic> oldData,
+  Map<String, dynamic> newData,
+) {
+  newData.forEach((String key, dynamic value) {
+    if (oldData.containsKey(key) &&
+        oldData[key] is Map &&
+        value != null &&
+        value is Map) {
+      _recursiveAddAll(oldData[key], value);
+    } else {
+      oldData[key] = value;
+    }
+  });
+}
 
 class InMemoryCache implements Cache {
   InMemoryCache({
@@ -38,7 +52,7 @@ class InMemoryCache implements Cache {
         value != null &&
         value is Map) {
       // Avoid overriding a superset with a subset of a field (#155)
-      _inMemoryCache[key].addAll(value);
+      _recursiveAddAll(_inMemoryCache[key], value);
     } else {
       _inMemoryCache[key] = value;
     }

--- a/lib/src/cache/in_memory.dart
+++ b/lib/src/cache/in_memory.dart
@@ -40,6 +40,7 @@ class InMemoryCache implements Cache {
         value != null &&
         value is Map) {
       // Avoid overriding a superset with a subset of a field (#155)
+      // this means deletions must be done by explicitly returning a field as null
       _inMemoryCache[key] = deeplyMergeLeft(<Map<String, dynamic>>[
         _inMemoryCache[key],
         value,

--- a/lib/src/cache/in_memory.dart
+++ b/lib/src/cache/in_memory.dart
@@ -2,24 +2,12 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
-import 'package:path_provider/path_provider.dart';
-import 'package:graphql_flutter/src/cache/cache.dart';
 
-void _recursiveAddAll(
-  Map<String, dynamic> oldData,
-  Map<String, dynamic> newData,
-) {
-  newData.forEach((String key, dynamic value) {
-    if (oldData.containsKey(key) &&
-        oldData[key] is Map &&
-        value != null &&
-        value is Map) {
-      _recursiveAddAll(oldData[key], value);
-    } else {
-      oldData[key] = value;
-    }
-  });
-}
+import 'package:path_provider/path_provider.dart';
+
+import 'package:graphql_flutter/src/cache/cache.dart';
+import 'package:graphql_flutter/src/utilities/helpers.dart'
+    show deeplyMergeLeft;
 
 class InMemoryCache implements Cache {
   InMemoryCache({
@@ -52,7 +40,10 @@ class InMemoryCache implements Cache {
         value != null &&
         value is Map) {
       // Avoid overriding a superset with a subset of a field (#155)
-      _recursiveAddAll(_inMemoryCache[key], value);
+      _inMemoryCache[key] = deeplyMergeLeft(<Map<String, dynamic>>[
+        _inMemoryCache[key],
+        value,
+      ]);
     } else {
       _inMemoryCache[key] = value;
     }

--- a/lib/src/utilities/helpers.dart
+++ b/lib/src/utilities/helpers.dart
@@ -1,3 +1,40 @@
 bool notNull(Object any) {
   return any != null;
 }
+
+Map<String, dynamic> _recursivelyAddAll(
+  Map<String, dynamic> target,
+  Map<String, dynamic> source,
+) {
+  source.forEach((String key, dynamic value) {
+    if (target.containsKey(key) &&
+        target[key] is Map &&
+        value != null &&
+        value is Map) {
+      _recursivelyAddAll(target[key], value);
+    } else {
+      target[key] = value;
+    }
+  });
+  return target;
+}
+
+/// Deeply merges `maps` into a new map, merging nested maps recursively.
+///
+/// Paths in the rightmost maps override those in the earlier ones, so:
+/// ```
+/// print(deeplyMergeLeft([
+///   {'keyA': 'a1'},
+///   {'keyA': 'a2', 'keyB': 'b2'},
+///   {'keyB': 'b3'}
+/// ]));
+/// // { keyA: a2, keyB: b3 }
+/// ```
+///
+Map<String, dynamic> deeplyMergeLeft(
+  Iterable<Map<String, dynamic>> maps,
+) {
+  // prepend an empty literal for functional immutability
+  return (<Map<String, dynamic>>[<String, dynamic>{}]..addAll(maps))
+      .reduce(_recursivelyAddAll);
+}

--- a/test/normalized_in_memory_test.dart
+++ b/test/normalized_in_memory_test.dart
@@ -31,6 +31,10 @@ final Map<String, Object> rawOperationData = <String, Object>{
       },
       'bField': <String, Object>{'field': true}
     },
+    'd': <String, Object>{
+      'id': 9,
+      'dField': <String, Object>{'field': true}
+    },
   },
   'aField': <String, Object>{'field': false}
 };
@@ -62,6 +66,10 @@ final Map<String, Object> updatedCOperationData = <String, Object>{
       'c': updatedCValue,
       'bField': <String, Object>{'field': true}
     },
+    'd': <String, Object>{
+      'id': 9,
+      'dField': <String, Object>{'field': true}
+    },
   },
   'aField': <String, Object>{'field': false}
 };
@@ -80,6 +88,9 @@ final Map<String, Object> subsetAValue = <String, Object>{
         'value': 8,
       }
     ],
+    'd': <String, Object>{
+      'id': 10,
+    },
   },
 };
 
@@ -102,6 +113,10 @@ final Map<String, Object> updatedSubsetOperationData = <String, Object>{
       'id': 5,
       'c': updatedCValue,
       'bField': <String, Object>{'field': true}
+    },
+    'd': <String, Object>{
+      'id': 10,
+      'dField': <String, Object>{'field': true}
     },
   },
   'aField': <String, Object>{'field': false}


### PR DESCRIPTION
It is a follow up to this PR: https://github.com/zino-app/graphql-flutter/pull/156
I ended up still having the issue where the subquery would override the superquery when there wasn't a typename on the field.

This PR adds tests for this edge case and fixes it.

I'm sorry I didn't put this all on the same PR.