### PR TITLE
Fixes incomplete cache restoration issue

### DIFF
--- a/lib/src/cache/in_memory.dart
+++ b/lib/src/cache/in_memory.dart
@@ -101,7 +101,6 @@ class InMemoryCache implements Cache {
         sink.writeln(json.encode(<dynamic>[key, value]));
       });
 
-      // before calling sink.close() we should call sink.flush()
       await sink.flush();
       await sink.close();
 
@@ -116,15 +115,6 @@ class InMemoryCache implements Cache {
 
   Future<HashMap<String, dynamic>> _readFromStorage() async {
     if (_writingToStorage) {
-      // On android the app will fire 'inactive' and then 'restored'
-      // when it is restored. Then, while this is reading it may read
-      // incomplete data because the writer may be writing data.
-      // And if it is writing the file was overwritten anyway, so we don't
-      // have what to read and best hope that the data we have in memory
-      // is the correct one.
-      // TODO: should we call save when the app enters inactive (why?)
-      // When the app is 'cold-started' then save won't be called and
-      // restore will run ok.
       return _inMemoryCache;
     }
     try {

--- a/lib/src/cache/in_memory.dart
+++ b/lib/src/cache/in_memory.dart
@@ -113,6 +113,10 @@ class InMemoryCache implements Cache {
     return;
   }
 
+  /// Attempts to read saved state from the file cache `_localStorageFile`.
+  ///
+  /// Will return the current in-memory cache if writing,
+  /// or an empty map on failure
   Future<HashMap<String, dynamic>> _readFromStorage() async {
     if (_writingToStorage) {
       return _inMemoryCache;

--- a/lib/src/widgets/cache_provider.dart
+++ b/lib/src/widgets/cache_provider.dart
@@ -49,6 +49,9 @@ class _CacheProviderState extends State<CacheProvider>
     assert(client != null);
 
     switch (state) {
+      // TODO: from @degroote22 in #175: reconsider saving on `inactive`
+      // When the app is 'cold-started', save won't be called and
+      // restore will run ok.
       case AppLifecycleState.inactive:
         client.cache?.save();
         break;


### PR DESCRIPTION
It follows https://github.com/zino-app/graphql-flutter/issues/152 and https://github.com/zino-app/graphql-flutter/pull/156  

__This basically fixes a race condition. `tl;dr` we can't read and write at the same time__:
On android the app will fire `inactive` and then `restored` when it is restored.
Then, while this is reading, it may read incomplete data because the writer may be writing data.
If it is writing, the file was overwritten anyway, so just hope that the data we have in memory is the correct one.

<details>
 <summary><b>extended context provided by <code>@degroote22</code></b></summary>

 I'm having a hard time creating a PR without the[ commits from Feb 19](https://github.com/zino-app/graphql-flutter/pull/174) which are unrelated to this issue but on the same file.[ This is the relevant commit.](https://github.com/zino-app/graphql-flutter/commit/54e8b65cde51a5a84791856cc449b2f1f9f0b1a1) The other ones are awaiting to be merged in another PR.

The reasoning behind the changes are written as comments in code.
I only have an Android device to test and this PR fixes my issues.
Like I said on the code, I'm in doubt about calling save when the app is inactive...
Is the reasoning that the user may have the app in this state and not paused and then the phone may turn off and the data will be saved?

This requires testing and I only have one device to test it.
Anyway, I have just one phone running Android 6 to test this and it works for me 🤷‍♂️ 
</details>
