### PR TITLE
✨ Changed getToken from `Future` to `FutureOr`

### DIFF
--- a/lib/src/link/auth/link_auth.dart
+++ b/lib/src/link/auth/link_auth.dart
@@ -4,7 +4,7 @@ import 'package:graphql_flutter/src/link/link.dart';
 import 'package:graphql_flutter/src/link/operation.dart';
 import 'package:graphql_flutter/src/link/fetch_result.dart';
 
-typedef GetToken = Future<String> Function();
+typedef GetToken = FutureOr<String> Function();
 
 class AuthLink extends Link {
   AuthLink({


### PR DESCRIPTION
This PR allows you to provide the token sync when it's already available.

#### Breaking changes

- N/A

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated the type of `getToken`.
