### PR TITLE
All the HTTP responses are now correctly decoded to utf8 before retur…

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -47,7 +47,7 @@ class Client {
 
   Map<String, String> get headers => {
         'Authorization': 'Bearer $apiToken',
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json; charset=utf-8',
       };
 
   InMemoryCache get cache => this._cache;
@@ -73,7 +73,8 @@ class Client {
       );
     }
 
-    final Map<String, dynamic> jsonResponse = json.decode(response.body);
+    final Map<String, dynamic> jsonResponse =
+        json.decode(utf8.decode(response.bodyBytes));
 
     if (jsonResponse['errors'] != null && jsonResponse['errors'].length > 0) {
       throw GQLException(


### PR DESCRIPTION
…n from the Client.query() method

In an HTTP request to a server that returns a response containing characters like: "Jiménez" the 'graphql_flutter' library returns from the Client.query() method a string like: "Jim@nez" because the response wasn't decoded to UTF-8. This pull request is a 'hotfix' to this issue.

#### Fixes / Enhancements

- Fixed the json utf8 decoding in responses from Client.query()
