### PR TITLE
expose runQuery Method to trigger Query Manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Query(
     bool loading,
     var data,
     Exception error,
+    runQuery
   }) {
     if (error != null) {
       return Text(error.toString());

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -4,10 +4,12 @@ import 'package:flutter/widgets.dart';
 import 'package:graphql_flutter/src/client.dart';
 import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 
+typedef void GetQueryResult();
 typedef Widget QueryBuilder({
   @required bool loading,
   Map<String, dynamic> data,
   Exception error,
+  GetQueryResult runQuery
 });
 
 class Query extends StatefulWidget {
@@ -160,6 +162,7 @@ class QueryState extends State<Query> {
       loading: loading,
       error: error,
       data: data,
+      runQuery: getQueryResult
     );
   }
 }


### PR DESCRIPTION
Describe the purpose of the pull request.

### Breaking changes
This changes breaks the basic query api, now it adds an `runQuery` extra param in the builder list of parameters

#### Fixes / Enhancements

- Adds the ability to trigger the query manually, until now it would require to call the client manually, or use a poll interval to update the refetch the query

#### Docs

- Before:

```dart
...

Query(
  readRepositories, // this is the query you just created
  variables: {
    'nRepositories': 50,
  },
  pollInterval: 10, // optional
  builder: ({
    bool loading,
    var data,
    Exception error
  }) {
    if (error != null) {
      return Text(error.toString());
    }

    if (loading) {
      return Text('Loading');
    }

    // it can be either Map or List
    List repositories = data['viewer']['repositories']['nodes'];

    return ListView.builder(
      itemCount: repositories.length,
      itemBuilder: (context, index) {
        final repository = repositories[index];

        return Text(repository['name']);
    });
  },
);

...
```

After:

```dart
...

Query(
  readRepositories, // this is the query you just created
  variables: {
    'nRepositories': 50,
  },
  pollInterval: 10, // optional
  builder: ({
    bool loading,
    var data,
    Exception error,
    runQuery
  }) {
    if (error != null) {
      return Text(error.toString());
    }

    if (loading) {
      return Text('Loading');
    }

    // it can be either Map or List
    List repositories = data['viewer']['repositories']['nodes'];

    return ListView.builder(
      itemCount: repositories.length,
      itemBuilder: (context, index) {
        final repository = repositories[index];

        return Text(repository['name']);
    });
  },
);

...
```