### PR TITLE
Verify errors are not null before JSON transform

### DIFF
--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -192,9 +192,11 @@ class QueryManager {
     List<GraphQLError> errors;
 
     if (fetchResult.errors != null) {
-      errors = List<GraphQLError>.from(fetchResult.errors.map<GraphQLError>(
-        (dynamic rawError) => GraphQLError.fromJSON(rawError),
-      ));
+      errors = List<GraphQLError>.from(
+        fetchResult.errors
+          .where((error) => error != null)
+          .map<GraphQLError>((dynamic rawError) => GraphQLError.fromJSON(rawError))
+      );
     }
 
     return QueryResult(

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -192,11 +192,9 @@ class QueryManager {
     List<GraphQLError> errors;
 
     if (fetchResult.errors != null) {
-      errors = List<GraphQLError>.from(
-        fetchResult.errors
-          .where((error) => error != null)
-          .map<GraphQLError>((dynamic rawError) => GraphQLError.fromJSON(rawError))
-      );
+      errors = List<GraphQLError>.from(fetchResult.errors.map<GraphQLError>(
+        (dynamic rawError) => GraphQLError.fromJSON(rawError),
+      ));
     }
 
     return QueryResult(

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -206,7 +206,9 @@ FetchResult _parseResponse(Response response) {
   final FetchResult fetchResult = FetchResult();
 
   if (jsonResponse['errors'] != null) {
-    fetchResult.errors = jsonResponse['errors'];
+    fetchResult.errors =
+      (jsonResponse['errors'] as List<Map<String, dynamic>>)
+      .where((error) => error != null);
   }
 
   if (jsonResponse['data'] != null) {

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -206,8 +206,7 @@ FetchResult _parseResponse(Response response) {
   final FetchResult fetchResult = FetchResult();
 
   if (jsonResponse['errors'] != null) {
-    fetchResult.errors =
-      (jsonResponse['errors'] as List<Map<String, dynamic>>)
+    fetchResult.errors = jsonResponse['errors']
       .where((error) => error != null);
   }
 

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -207,7 +207,8 @@ FetchResult _parseResponse(Response response) {
 
   if (jsonResponse['errors'] != null) {
     fetchResult.errors = jsonResponse['errors']
-      .where((error) => error != null);
+      .where((error) => error != null)
+      .toList();
   }
 
   if (jsonResponse['data'] != null) {


### PR DESCRIPTION
The jsonResponse is a list of nullable errors & can throw if assumed to be non-nullable...

**link_http.dart** (inspector)
```
> jsonResponse
Map (2 items)
0:"errors" -> List (1 item)
key:"errors"
value:List (1 item)
[0]:null
1:"data" -> Map (1 item)
key:"data"
value:Map (1 item)
0:"viewer" -> null
```