### PR TITLE
Optimistic Updates, Lazy Dereferences, Refetch queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Query(
 -    var data,
 -    String error,
 -  }) {
-+  builder: (QueryResult result, { VoidCallback refetch }) {
++  builder: (QueryResult result) {
 -    if (error != '') {
 -      return Text(error);
 +    if (result.errors != null) {

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Query(
 -    var data,
 -    String error,
 -  }) {
-+  builder: (QueryResult result) {
++  builder: (QueryResult result, { VoidCallback refetch }) {
 -    if (error != '') {
 -      return Text(error);
 +    if (result.errors != null) {

--- a/README.md
+++ b/README.md
@@ -270,13 +270,13 @@ String typenameDataIdFromObject(Object object) {
 
 However note that **`graphql-flutter` does not inject \_\_typename into operations** the way apollo does, so if you aren't careful to request them in your query, this normalization scheme is not possible.
 
-Unlike apollo, we don't have a real client side document parser and resolver, so **operations leveraging normalization can have additional fields not specified in the query**. There are a couple ideas for constraining this (leveraging `json_serializable`, or just implementing the resolver), but for now, the normalized cache uses a [`LazyMap`](lib/src/cache/lazy_cache_map.dart), which wraps underlying data with a lazy denormalizer to allow for cyclical references. It has the same API as a normal `HashMap`, but is currently a bit hard to debug with, as a descriptive debug representation is currently unavailable.
+Unlike apollo, we don't have a real client side document parser and resolver, so **operations leveraging normalization can have additional fields not specified in the query**. There are a couple ideas for constraining this (leveraging `json_serializable`, or just implementing the resolver), but for now, the normalized cache uses a [`LazyCacheMap`](lib/src/cache/lazy_cache_map.dart), which wraps underlying data with a lazy denormalizer to allow for cyclical references. It has the same API as a normal `HashMap`, but is currently a bit hard to debug with, as a descriptive debug representation is currently unavailable.
 
 #### Optimism
-The `OptimisticCache` allows for optimistic mutations by passing an `optimisticResult` to `RunMutation`. It will then call `update(Cache cache, QueryResult result)` twice (once eagerly with `optimisticResult`), and rebroadcast all queries with the optimistic cache. You can tell which entities in the cache are optimistic through the `.isOptimistic` flag on `LazyMap`, though note that **this is only the case for optimistic entities and not their containing operations/maps**.
+
+The `OptimisticCache` allows for optimistic mutations by passing an `optimisticResult` to `RunMutation`. It will then call `update(Cache cache, QueryResult result)` twice (once eagerly with `optimisticResult`), and rebroadcast all queries with the optimistic cache. You can tell which entities in the cache are optimistic through the `.isOptimistic` flag on `LazyCacheMap`, though note that **this is only the case for optimistic entities and not their containing operations/maps**.
 
 `QueryResults` also have an `optimistic` flag, but I would recommend looking at the data itself, as many situations make it unusable (such as toggling mutations like in the example below). [Mutation usage examples](#mutations-with-optimism)
-
 
 ### Queries
 
@@ -386,7 +386,9 @@ Mutation(
 ```
 
 #### Mutations with optimism
+
 If you're using an [OptimisticCache](#optimism), you can provide an `optimisticResult`:
+
 ```dart
 ...
 FlutterWidget(
@@ -403,10 +405,12 @@ FlutterWidget(
 )
 ...
 ```
+
 With a bit more context (taken from **[the complete mutation example `StarrableRepository`](example/lib/graphql_widget/main.dart)**):
+
 ```dart
 // bool get starred => repository['viewerHasStarred'] as bool;
-// bool get optimistic => (repository as LazyMap).isOptimistic;
+// bool get optimistic => (repository as LazyCacheMap).isOptimistic;
 Mutation(
   options: MutationOptions(
     document: starred ? mutations.removeStar : mutations.addStar,

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ However note that **`graphql-flutter` does not inject \_\_typename into operatio
 
 Unlike apollo, we don't have a real client side document parser and resolver, so **operations leveraging normalization can have additional fields not specified in the query**. There are a couple ideas for constraining this (leveraging `json_serializable`, or just implementing the resolver), but for now, the normalized cache uses a [`LazyCacheMap`](lib/src/cache/lazy_cache_map.dart), which wraps underlying data with a lazy denormalizer to allow for cyclical references. It has the same API as a normal `HashMap`, but is currently a bit hard to debug with, as a descriptive debug representation is currently unavailable.
 
+NOTE: A `LazyCacheMap` can be modified, but this does not effect the underlying entities in the cache. If references are added to the map, they will still dereference against the cache normally.
+
 #### Optimism
 
 The `OptimisticCache` allows for optimistic mutations by passing an `optimisticResult` to `RunMutation`. It will then call `update(Cache cache, QueryResult result)` twice (once eagerly with `optimisticResult`), and rebroadcast all queries with the optimistic cache. You can tell which entities in the cache are optimistic through the `.isOptimistic` flag on `LazyCacheMap`, though note that **this is only the case for optimistic entities and not their containing operations/maps**.

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		9235FC581E2F702C430A0573 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		9740EEBA1CF902C7004384FC /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = Flutter/Flutter.framework; sourceTree = "<group>"; };
@@ -56,8 +57,12 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+<<<<<<< HEAD
 		E29A4DD2634FD1650C759381 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		FC5764D6533704F228337620 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+=======
+		C9CB04F761683177D49AF7FB /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+>>>>>>> artifact
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,8 +146,13 @@
 		C4CD52B830EB22224036641E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+<<<<<<< HEAD
 				FC5764D6533704F228337620 /* Pods-Runner.debug.xcconfig */,
 				E29A4DD2634FD1650C759381 /* Pods-Runner.release.xcconfig */,
+=======
+				9235FC581E2F702C430A0573 /* Pods-Runner.debug.xcconfig */,
+				C9CB04F761683177D49AF7FB /* Pods-Runner.release.xcconfig */,
+>>>>>>> artifact
 			);
 			name = Pods;
 			sourceTree = "<group>";

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -57,12 +57,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-<<<<<<< HEAD
-		E29A4DD2634FD1650C759381 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		FC5764D6533704F228337620 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-=======
 		C9CB04F761683177D49AF7FB /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
->>>>>>> artifact
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,13 +141,8 @@
 		C4CD52B830EB22224036641E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-<<<<<<< HEAD
-				FC5764D6533704F228337620 /* Pods-Runner.debug.xcconfig */,
-				E29A4DD2634FD1650C759381 /* Pods-Runner.release.xcconfig */,
-=======
 				9235FC581E2F702C430A0573 /* Pods-Runner.debug.xcconfig */,
 				C9CB04F761683177D49AF7FB /* Pods-Runner.release.xcconfig */,
->>>>>>> artifact
 			);
 			name = Pods;
 			sourceTree = "<group>";

--- a/example/lib/graphql_widget/main.dart
+++ b/example/lib/graphql_widget/main.dart
@@ -66,7 +66,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int nRepositories = 50;
+  int nRepositories = 1;
 
   void changeQuery(String number) {
     setState(() {
@@ -99,7 +99,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 variables: <String, dynamic>{
                   'nRepositories': nRepositories,
                 },
-                pollInterval: 4,
+                //pollInterval: 10,
               ),
               builder: (QueryResult result, {VoidCallback refetch}) {
                 if (result.loading) {
@@ -170,14 +170,9 @@ class StarrableRepository extends StatelessWidget {
 
   bool get starred => repository['viewerHasStarred'] as bool;
 
-  bool get loading => repository['_loading'] == true;
-
   Map<String, dynamic> get expectedResult => <String, dynamic>{
         'action': <String, dynamic>{
-          'starrable': <String, dynamic>{
-            'viewerHasStarred': !starred,
-            '_loading': true
-          }
+          'starrable': <String, dynamic>{'viewerHasStarred': !starred}
         }
       };
 
@@ -195,7 +190,9 @@ class StarrableRepository extends StatelessWidget {
                   color: Colors.amber,
                 )
               : const Icon(Icons.star_border),
-          trailing: loading ? const CircularProgressIndicator() : null,
+          trailing: result.loading || result.optimistic
+              ? const CircularProgressIndicator()
+              : null,
           title: Text(repository['name'] as String),
           onTap: () {
             toggleStar(

--- a/example/lib/graphql_widget/main.dart
+++ b/example/lib/graphql_widget/main.dart
@@ -208,7 +208,7 @@ class StarrableRepository extends StatelessWidget {
       },
       update: (Cache cache, QueryResult result) {
         if (result.hasErrors) {
-          print(['optimistic', result.errors]);
+          print(result.errors);
         } else {
           final Map<String, Object> updated =
               Map<String, Object>.from(repository)

--- a/example/lib/graphql_widget/main.dart
+++ b/example/lib/graphql_widget/main.dart
@@ -117,10 +117,11 @@ class _MyHomePageState extends State<MyHomePage> {
                       'Both data and errors are null, this is a known bug after refactoring, you might forget to set Github token');
                 }
 
+                print(result.data is LazyCacheMap);
                 // result.data can be either a [List<dynamic>] or a [Map<String, dynamic>]
-                final List<LazyMap> repositories = (result.data['viewer']
+                final List<LazyCacheMap> repositories = (result.data['viewer']
                         ['repositories']['nodes'] as List<dynamic>)
-                    .cast<LazyMap>();
+                    .cast<LazyCacheMap>();
 
                 return Expanded(
                   child: ListView.builder(
@@ -170,7 +171,7 @@ class StarrableRepository extends StatelessWidget {
   }
 
   bool get starred => repository['viewerHasStarred'] as bool;
-  bool get optimistic => (repository as LazyMap).isOptimistic;
+  bool get optimistic => (repository as LazyCacheMap).isOptimistic;
 
   Map<String, dynamic> get expectedResult => <String, dynamic>{
         'action': <String, dynamic>{
@@ -185,6 +186,7 @@ class StarrableRepository extends StatelessWidget {
         document: starred ? mutations.removeStar : mutations.addStar,
       ),
       builder: (RunMutation toggleStar, QueryResult result) {
+        print([result.loading, optimistic]);
         return ListTile(
           leading: starred
               ? const Icon(
@@ -214,6 +216,7 @@ class StarrableRepository extends StatelessWidget {
               Map<String, Object>.from(repository)
                 ..addAll(extractRepositoryData(result.data));
           cache.write(typenameDataIdFromObject(updated), updated);
+          print(cache.read(typenameDataIdFromObject(updated)).isOptimistic);
         }
       },
       onCompleted: (dynamic resultData) {

--- a/example/lib/graphql_widget/main.dart
+++ b/example/lib/graphql_widget/main.dart
@@ -228,7 +228,7 @@ class StarrableRepository extends StatelessWidget {
               ),
               actions: <Widget>[
                 SimpleDialogOption(
-                  child: const Text('Dismiss'),
+                  child: const Text('DISMISS'),
                   onPressed: () {
                     Navigator.of(context).pop();
                   },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import './graphql_bloc/main.dart' show GraphQLBlocPatternScreen;
-import './graphql_widget/main.dart' show GraphQLWidgetScreen;
+import 'package:app/graphql_bloc/main.dart' show GraphQLBlocPatternScreen;
+import 'package:app/graphql_widget/main.dart' show GraphQLWidgetScreen;
 
 void main() => runApp(
       MaterialApp(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:app/graphql_bloc/main.dart' show GraphQLBlocPatternScreen;
-import 'package:app/graphql_widget/main.dart' show GraphQLWidgetScreen;
+import './graphql_bloc/main.dart' show GraphQLBlocPatternScreen;
+import './graphql_widget/main.dart' show GraphQLWidgetScreen;
 
 void main() => runApp(
       MaterialApp(

--- a/lib/graphql_flutter.dart
+++ b/lib/graphql_flutter.dart
@@ -3,6 +3,9 @@ library graphql_flutter;
 export 'package:graphql_flutter/src/cache/cache.dart';
 export 'package:graphql_flutter/src/cache/in_memory.dart';
 export 'package:graphql_flutter/src/cache/normalized_in_memory.dart';
+export 'package:graphql_flutter/src/cache/optimistic.dart';
+export 'package:graphql_flutter/src/cache/lazy_cache_map.dart';
+
 export 'package:graphql_flutter/src/core/graphql_error.dart';
 export 'package:graphql_flutter/src/core/query_manager.dart';
 export 'package:graphql_flutter/src/core/query_options.dart';
@@ -13,7 +16,6 @@ export 'package:graphql_flutter/src/link/http/link_http.dart';
 export 'package:graphql_flutter/src/link/link.dart';
 export 'package:graphql_flutter/src/link/web_socket/link_web_socket.dart';
 export 'package:graphql_flutter/src/socket_client.dart';
-export 'package:graphql_flutter/src/cache/optimistic.dart';
 
 export 'package:graphql_flutter/src/websocket/messages.dart';
 export 'package:graphql_flutter/src/widgets/cache_provider.dart';

--- a/lib/graphql_flutter.dart
+++ b/lib/graphql_flutter.dart
@@ -13,6 +13,8 @@ export 'package:graphql_flutter/src/link/http/link_http.dart';
 export 'package:graphql_flutter/src/link/link.dart';
 export 'package:graphql_flutter/src/link/web_socket/link_web_socket.dart';
 export 'package:graphql_flutter/src/socket_client.dart';
+export 'package:graphql_flutter/src/cache/optimistic.dart';
+
 export 'package:graphql_flutter/src/websocket/messages.dart';
 export 'package:graphql_flutter/src/widgets/cache_provider.dart';
 export 'package:graphql_flutter/src/widgets/graphql_consumer.dart';

--- a/lib/src/cache/in_memory.dart
+++ b/lib/src/cache/in_memory.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:meta/meta.dart';
 import 'package:path_provider/path_provider.dart';
+
 import 'package:graphql_flutter/src/cache/cache.dart';
 import 'package:graphql_flutter/src/utilities/helpers.dart'
     show deeplyMergeLeft;
@@ -125,7 +126,7 @@ class InMemoryCache implements Cache {
     }
     try {
       final File file = await _localStorageFile;
-      final HashMap<String, dynamic> storedHashMap = HashMap<String, dynamic>();
+      final storedHashMap = HashMap<String, dynamic>();
 
       if (file.existsSync()) {
         final Stream<List<int>> inputStream = file.openRead();

--- a/lib/src/cache/lazy_cache_map.dart
+++ b/lib/src/cache/lazy_cache_map.dart
@@ -1,5 +1,5 @@
 import 'dart:core';
-import 'dart:core';
+
 import 'package:meta/meta.dart';
 
 typedef Dereference = Object Function(Object node);

--- a/lib/src/cache/lazy_cache_map.dart
+++ b/lib/src/cache/lazy_cache_map.dart
@@ -1,9 +1,24 @@
 import 'dart:core';
+import 'dart:core';
 import 'package:meta/meta.dart';
 
 typedef Dereference = Object Function(Object node);
 
-class LazyMap {
+/// A simple immutable map that lazily dereferences from the cache
+/// The only available methods are simple read-based operations,
+/// such as `[]()`, `containsKey`, and `values`
+/// All mutation methods are invalid:
+/// * `[]=`
+/// * `addAll`
+/// * `addEntries`
+/// * `clear`
+/// * `remove`
+/// * `removeWhere`
+/// * `update`
+/// * `updateAll`
+/// * `putIfAbsent`
+/// As well as `cast`
+class LazyMap implements Map<String, Object> {
   LazyMap({
     @required this.data,
     @required Dereference dereference,
@@ -13,8 +28,83 @@ class LazyMap {
 
   final Map<String, Object> data;
 
-  Object operator [](Object key) {
-    final Object value = data[key];
-    return _dereference(value) ?? value;
+  Object _getValue(Object value) {
+    final Object result = _dereference(value) ?? value;
+    // TODO maybe this should be encapsulated in a LazyList or something
+    if (result is List) {
+      return result.map(_getValue).toList();
+    }
+    if (result is Map<String, Object>) {
+      return LazyMap(
+        data: result,
+        dereference: _dereference,
+      );
+    }
+    return result;
   }
+
+  @override
+  Object operator [](Object key) => _getValue(data[key]);
+
+  @override
+  bool containsKey(Object key) => data.containsKey(key);
+
+  @override
+  bool containsValue(Object value) => values.contains(value);
+
+  @override
+  Iterable<MapEntry<String, Object>> get entries => data.entries
+      .map((MapEntry<String, Object> entry) => MapEntry<String, Object>(
+            entry.key,
+            _getValue(entry.value),
+          ));
+
+  @override
+  void forEach(void Function(String key, Object value) f) {
+    void _forEachEntry(MapEntry<String, Object> entry) {
+      f(entry.key, entry.value);
+    }
+
+    entries.forEach(_forEachEntry);
+  }
+
+  @override
+  bool get isEmpty => data.isEmpty;
+
+  @override
+  bool get isNotEmpty => data.isNotEmpty;
+
+  @override
+  Iterable<String> get keys => data.keys;
+
+  @override
+  int get length => data.length;
+
+  @override
+  Map<K2, V2> map<K2, V2>(
+      MapEntry<K2, V2> Function(String key, Object value) f) {
+    MapEntry<K2, V2> _mapEntry(MapEntry<String, Object> entry) {
+      return f(entry.key, entry.value);
+    }
+
+    return Map<K2, V2>.fromEntries(entries.map(_mapEntry));
+  }
+
+  @override
+  Iterable<Object> get values => data.values.map(_getValue);
+
+  @override
+
+  /// All mutation methods are invalid:
+  /// * `[]=`
+  /// * `addAll`
+  /// * `addEntries`
+  /// * `clear`
+  /// * `remove`
+  /// * `removeWhere`
+  /// * `update`
+  /// * `updateAll`
+  /// * `putIfAbsent`
+  /// As well as `cast`
+  void noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/lib/src/cache/lazy_cache_map.dart
+++ b/lib/src/cache/lazy_cache_map.dart
@@ -20,13 +20,15 @@ typedef Dereference = Object Function(Object node);
 /// As well as `cast`
 class LazyMap implements Map<String, Object> {
   LazyMap({
-    @required this.data,
+    @required Map<String, Object> data,
     @required Dereference dereference,
-  }) : _dereference = dereference;
+  })  : _data = data is LazyMap ? data.data : data,
+        _dereference = dereference;
 
   Dereference _dereference;
 
-  final Map<String, Object> data;
+  final Map<String, Object> _data;
+  Map<String, Object> get data => _data;
 
   Object _getValue(Object value) {
     final Object result = _dereference(value) ?? value;
@@ -44,7 +46,9 @@ class LazyMap implements Map<String, Object> {
   }
 
   @override
-  Object operator [](Object key) => _getValue(data[key]);
+  Object operator [](Object key) {
+    return _getValue(data[key]);
+  }
 
   @override
   bool containsKey(Object key) => data.containsKey(key);

--- a/lib/src/cache/lazy_cache_map.dart
+++ b/lib/src/cache/lazy_cache_map.dart
@@ -1,0 +1,20 @@
+import 'dart:core';
+import 'package:meta/meta.dart';
+
+typedef Dereference = Object Function(Object node);
+
+class LazyMap {
+  LazyMap({
+    @required this.data,
+    @required Dereference dereference,
+  }) : _dereference = dereference;
+
+  Dereference _dereference;
+
+  final Map<String, Object> data;
+
+  Object operator [](Object key) {
+    final Object value = data[key];
+    return _dereference(value) ?? value;
+  }
+}

--- a/lib/src/cache/lazy_cache_map.dart
+++ b/lib/src/cache/lazy_cache_map.dart
@@ -4,6 +4,8 @@ import 'package:meta/meta.dart';
 
 typedef Dereference = Object Function(Object node);
 
+enum CacheState { OPTIMISTIC }
+
 /// A simple immutable map that lazily dereferences from the cache
 /// The only available methods are simple read-based operations,
 /// such as `[]()`, `containsKey`, and `values`
@@ -22,10 +24,16 @@ class LazyMap implements Map<String, Object> {
   LazyMap({
     @required Map<String, Object> data,
     @required Dereference dereference,
+    CacheState cacheState,
   })  : _data = data is LazyMap ? data.data : data,
-        _dereference = dereference;
+        _dereference = dereference,
+        this.cacheState =
+            cacheState ?? (data is LazyMap ? data.cacheState : null);
 
   Dereference _dereference;
+
+  final CacheState cacheState;
+  bool get isOptimistic => cacheState == CacheState.OPTIMISTIC;
 
   final Map<String, Object> _data;
   Map<String, Object> get data => _data;

--- a/lib/src/cache/lazy_cache_map.dart
+++ b/lib/src/cache/lazy_cache_map.dart
@@ -50,6 +50,10 @@ class LazyMap implements Map<String, Object> {
     return _getValue(data[key]);
   }
 
+  Object get(Object key) {
+    return _getValue(data[key]);
+  }
+
   @override
   bool containsKey(Object key) => data.containsKey(key);
 

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -30,18 +30,30 @@ class NormalizedInMemoryCache extends InMemoryCache {
   DataIdFromObject dataIdFromObject;
   String prefix;
 
-  Object _dereference(Object node) {
-    if (node is List && _isReference(node)) {
-      return read(node[1] as String);
+  Dereference get _dereference {
+    final Map<String, Object> seen = <String, Object>{};
+    Object dereference(Object node) {
+      if (node is List && _isReference(node)) {
+        final String key = node[1] as String;
+        if (seen.containsKey(key)) {
+          return seen[key];
+        }
+        return read(key, dereference: dereference);
+      }
+
+      return null;
     }
 
-    return null;
+    return dereference;
   }
 
-  LazyMap lazilyDenormalized(Map<String, Object> data) {
+  LazyMap lazilyDenormalized(
+    Map<String, Object> data, {
+    Dereference dereference,
+  }) {
     return LazyMap(
       data: data,
-      dereference: _dereference,
+      dereference: dereference ?? _dereference,
     );
   }
 
@@ -78,9 +90,14 @@ class NormalizedInMemoryCache extends InMemoryCache {
     replacing them with cached instances
   */
   @override
-  dynamic read(String key) {
+  dynamic read(
+    String key, {
+    Dereference dereference,
+  }) {
     final Object value = super.read(key);
-    return value is Map<String, Object> ? lazilyDenormalized(value) : value;
+    return value is Map<String, Object>
+        ? lazilyDenormalized(value, dereference: dereference ?? _dereference)
+        : value;
   }
 
   Normalizer _normalizerFor(Map<String, Object> into) {

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -93,8 +93,10 @@ class NormalizedInMemoryCache extends InMemoryCache {
     Map<String, Object> into, [
     Normalizer normalizer,
   ]) {
-    final Object normalized =
-        traverseValues(value, normalizer ?? _normalizerFor(into));
+    // writing non-map data to the store is allowed
+    final Object normalized = value is Map<String, Object>
+        ? traverseValues(value, normalizer ?? _normalizerFor(into))
+        : value;
     into[key] = normalized;
   }
 

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -40,10 +40,14 @@ class NormalizedInMemoryCache extends InMemoryCache {
     return null;
   }
 
-  LazyMap lazilyDenormalized(Map<String, Object> data) {
+  LazyMap lazilyDenormalized(
+    Map<String, Object> data, [
+    CacheState cacheState,
+  ]) {
     return LazyMap(
       data: data,
       dereference: _dereference,
+      cacheState: cacheState,
     );
   }
 

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 import 'package:graphql_flutter/src/utilities/traverse.dart';
+import 'package:graphql_flutter/src/utilities/helpers.dart';
 import 'package:graphql_flutter/src/cache/in_memory.dart';
 
 import './lazy_cache_map.dart';
@@ -121,7 +122,7 @@ class NormalizedInMemoryCache extends InMemoryCache {
     final Object existing = into[key];
     into[key] =
         (existing is Map<String, Object> && normalized is Map<String, Object>)
-            ? (existing..addAll(normalized))
+            ? deeplyMergeLeft(<Map<String, Object>>[existing, normalized])
             : normalized;
   }
 

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -38,10 +38,9 @@ class NormalizedInMemoryCache extends InMemoryCache {
     return null;
   }
 
-  LazyMap lazilyDenormalized(Object data) {
-    // TODO typping
+  LazyMap lazilyDenormalized(Map<String, Object> data) {
     return LazyMap(
-      data: data as Map<String, Object>,
+      data: data,
       dereference: _dereference,
     );
   }
@@ -79,8 +78,9 @@ class NormalizedInMemoryCache extends InMemoryCache {
     replacing them with cached instances
   */
   @override
-  LazyMap read(String key) {
-    return lazilyDenormalized(super.read(key));
+  dynamic read(String key) {
+    final Object value = super.read(key);
+    return value is Map<String, Object> ? lazilyDenormalized(value) : value;
   }
 
   Normalizer _normalizerFor(Map<String, Object> into) {

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -115,15 +115,19 @@ class NormalizedInMemoryCache extends InMemoryCache {
     Map<String, Object> into, [
     Normalizer normalizer,
   ]) {
-    // writing non-map data to the store is allowed
-    final Object normalized = value is Map<String, Object>
-        ? traverseValues(value, normalizer ?? _normalizerFor(into))
-        : value;
-    final Object existing = into[key];
-    into[key] =
-        (existing is Map<String, Object> && normalized is Map<String, Object>)
-            ? deeplyMergeLeft(<Map<String, Object>>[existing, normalized])
-            : normalized;
+    if (value is Map<String, Object>) {
+      final Object existing = into[key];
+      final Map<String, Object> merged = (existing is Map<String, Object>)
+          ? deeplyMergeLeft(<Map<String, Object>>[existing, value])
+          : value;
+
+      // normalized the merged value
+      into[key] = traverseValues(merged, normalizer ?? _normalizerFor(into));
+    } else {
+      // writing non-map data to the store is allowed,
+      // but there is no merging strategy
+      into[key] = value;
+    }
   }
 
   /// Writes included objects to store,

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -7,11 +7,11 @@ import './lazy_cache_map.dart';
 typedef DataIdFromObject = String Function(Object node);
 
 class NormalizationException implements Exception {
+  NormalizationException(this.cause, this.overflowError, this.value);
+
   StackOverflowError overflowError;
   String cause;
   Object value;
-
-  NormalizationException(this.cause, this.overflowError, this.value);
 
   String get message => cause;
 }
@@ -19,14 +19,14 @@ class NormalizationException implements Exception {
 typedef Normalizer = List<String> Function(Object node);
 
 class NormalizedInMemoryCache extends InMemoryCache {
-  DataIdFromObject dataIdFromObject;
-
-  String prefix;
-
   NormalizedInMemoryCache({
     @required this.dataIdFromObject,
     this.prefix = '@cache/reference',
   });
+
+  DataIdFromObject dataIdFromObject;
+
+  String prefix;
 
   bool _isReference(Object node) =>
       node is List && node.length == 2 && node[0] == prefix;

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -74,7 +74,7 @@ class NormalizedInMemoryCache extends InMemoryCache {
   }
 
   /*
-    Derefrences object references,
+    Dereferences object references,
     replacing them with cached instances
   */
   @override
@@ -107,10 +107,8 @@ class NormalizedInMemoryCache extends InMemoryCache {
     return null;
   }
 
-  /*
-    Writes included objects to provided Map,
-    replacing them with references
-  */
+  /// Writes included objects to provided Map,
+  /// replacing discernable entities with references
   void writeInto(
     String key,
     Object value,
@@ -124,10 +122,8 @@ class NormalizedInMemoryCache extends InMemoryCache {
     into[key] = normalized;
   }
 
-  /*
-    Writes included objects to store,
-    replacing them with references
-  */
+  /// Writes included objects to store,
+  /// replacing discernable entities with references
   @override
   void write(String key, Object value) {
     writeInto(key, value, data, _normalize);

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -1,9 +1,9 @@
 import 'package:meta/meta.dart';
+
 import 'package:graphql_flutter/src/utilities/traverse.dart';
 import 'package:graphql_flutter/src/utilities/helpers.dart';
 import 'package:graphql_flutter/src/cache/in_memory.dart';
-
-import './lazy_cache_map.dart';
+import 'package:graphql_flutter/src/cache/lazy_cache_map.dart';
 
 typedef DataIdFromObject = String Function(Object node);
 

--- a/lib/src/cache/normalized_in_memory.dart
+++ b/lib/src/cache/normalized_in_memory.dart
@@ -40,12 +40,12 @@ class NormalizedInMemoryCache extends InMemoryCache {
     return null;
   }
 
-  LazyMap lazilyDenormalized(
+  LazyCacheMap lazilyDenormalized(
     Map<String, Object> data, [
     CacheState cacheState,
   ]) {
-    return LazyMap(
-      data: data,
+    return LazyCacheMap(
+      data,
       dereference: _dereference,
       cacheState: cacheState,
     );

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -51,7 +51,6 @@ class OptimisticCache extends NormalizedInMemoryCache {
   /// defaulting to the base internal HashMap.
   @override
   dynamic read(String key) {
-    print(optimisticPatches);
     for (OptimisticPatch patch in optimisticPatches) {
       if (patch.data.containsKey(key)) {
         return denormalize(patch.data[key]);

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -10,7 +10,7 @@ class OptimisticPatch extends Object {
 }
 
 class OptimisticProxy implements Cache {
-  OptimisticNormalizedInMemoryCache cache;
+  OptimisticCache cache;
   HashMap<String, dynamic> data = HashMap<String, dynamic>();
   OptimisticProxy(this.cache);
 
@@ -38,14 +38,20 @@ class OptimisticProxy implements Cache {
 
 typedef Cache CacheTransform(Cache proxy);
 
-class OptimisticNormalizedInMemoryCache extends NormalizedInMemoryCache {
+class OptimisticCache extends NormalizedInMemoryCache {
   @protected
   List<OptimisticPatch> optimisticPatches = <OptimisticPatch>[];
+
+  OptimisticCache({
+    @required DataIdFromObject dataIdFromObject,
+    String prefix = '@cache/reference',
+  }) : super(dataIdFromObject: dataIdFromObject, prefix: prefix);
 
   /// Reads and dereferences an entity from the first valid optimistic layer,
   /// defaulting to the base internal HashMap.
   @override
   dynamic read(String key) {
+    print(optimisticPatches);
     for (OptimisticPatch patch in optimisticPatches) {
       if (patch.data.containsKey(key)) {
         return denormalize(patch.data[key]);

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+
 import 'package:meta/meta.dart';
 import 'package:graphql_flutter/src/cache/cache.dart';
 import 'package:graphql_flutter/src/cache/normalized_in_memory.dart';
@@ -18,7 +19,7 @@ class OptimisticProxy implements Cache {
 
   Object _dereference(Object node) {
     if (node is List && node.length == 2 && node[0] == cache.prefix) {
-      return read(node[1]);
+      return read(node[1] as String);
     }
 
     return null;
@@ -28,7 +29,7 @@ class OptimisticProxy implements Cache {
   dynamic read(String key) {
     if (data.containsKey(key)) {
       final Object value = data[key];
-      return value is Map
+      return value is Map<String, Object>
           ? LazyMap(data: value, dereference: _dereference)
           : value;
     }
@@ -49,7 +50,7 @@ class OptimisticProxy implements Cache {
   void reset() {}
 }
 
-typedef Cache CacheTransform(Cache proxy);
+typedef CacheTransform = Cache Function(Cache proxy);
 
 class OptimisticCache extends NormalizedInMemoryCache {
   @protected
@@ -69,7 +70,9 @@ class OptimisticCache extends NormalizedInMemoryCache {
       if (patch.data.containsKey(key)) {
         final Object patchData = patch.data[key];
         if (value is Map<String, Object> && patchData is Map<String, Object>) {
-          value = patchData..addAll(value is LazyMap ? value.data : value);
+          value = patchData
+            ..addAll(
+                value is LazyMap ? value.data : value as Map<String, Object>);
         } else {
           // Overwrite if not mergable
           value = patchData;
@@ -85,7 +88,7 @@ class OptimisticCache extends NormalizedInMemoryCache {
     String addId,
     CacheTransform transform,
   ) {
-    final OptimisticProxy patch = transform(_proxy);
+    final OptimisticProxy patch = transform(_proxy) as OptimisticProxy;
     optimisticPatches.add(OptimisticPatch(addId, patch.data));
   }
 

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -71,7 +71,7 @@ class OptimisticCache extends NormalizedInMemoryCache {
 
   void removeOptimisticPatch(String removeId) {
     optimisticPatches.removeWhere(
-      (OptimisticPatch patch) => patch.id != removeId,
+      (OptimisticPatch patch) => patch.id == removeId,
     );
   }
 }

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -51,7 +51,7 @@ class OptimisticCache extends NormalizedInMemoryCache {
   /// defaulting to the base internal HashMap.
   @override
   dynamic read(String key) {
-    for (OptimisticPatch patch in optimisticPatches) {
+    for (OptimisticPatch patch in optimisticPatches.reversed) {
       if (patch.data.containsKey(key)) {
         return denormalize(patch.data[key]);
       }
@@ -66,7 +66,7 @@ class OptimisticCache extends NormalizedInMemoryCache {
     CacheTransform transform,
   ) {
     final OptimisticProxy patch = transform(_proxy);
-    optimisticPatches.insert(0, OptimisticPatch(addId, patch.data));
+    optimisticPatches.add(OptimisticPatch(addId, patch.data));
   }
 
   void removeOptimisticPatch(String removeId) {

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -69,6 +69,7 @@ class OptimisticCache extends NormalizedInMemoryCache {
         return lazilyDenormalized(patch.data[key]);
       }
     }
+
     return super.read(key);
   }
 

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -27,7 +27,10 @@ class OptimisticProxy implements Cache {
   @override
   dynamic read(String key) {
     if (data.containsKey(key)) {
-      return LazyMap(data: data[key], dereference: _dereference);
+      final Object value = data[key];
+      return value is Map
+          ? LazyMap(data: value, dereference: _dereference)
+          : value;
     }
     return cache.read(key);
   }
@@ -60,7 +63,7 @@ class OptimisticCache extends NormalizedInMemoryCache {
   /// Reads and dereferences an entity from the first valid optimistic layer,
   /// defaulting to the base internal HashMap.
   @override
-  LazyMap read(String key) {
+  dynamic read(String key) {
     for (OptimisticPatch patch in optimisticPatches.reversed) {
       if (patch.data.containsKey(key)) {
         return lazilyDenormalized(patch.data[key]);

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -1,11 +1,11 @@
 import 'dart:collection';
 
 import 'package:meta/meta.dart';
+
+import 'package:graphql_flutter/src/utilities/helpers.dart';
 import 'package:graphql_flutter/src/cache/cache.dart';
 import 'package:graphql_flutter/src/cache/normalized_in_memory.dart';
-import 'package:graphql_flutter/src/utilities/helpers.dart';
-
-import './lazy_cache_map.dart';
+import 'package:graphql_flutter/src/cache/lazy_cache_map.dart';
 
 class OptimisticPatch extends Object {
   OptimisticPatch(this.id, this.data);

--- a/lib/src/cache/optimistic_normalized_in_memory.dart
+++ b/lib/src/cache/optimistic_normalized_in_memory.dart
@@ -1,0 +1,72 @@
+import 'dart:collection';
+import 'package:meta/meta.dart';
+import 'package:graphql_flutter/src/cache/cache.dart';
+import 'package:graphql_flutter/src/cache/normalized_in_memory.dart';
+
+class OptimisticPatch extends Object {
+  String id;
+  HashMap<String, dynamic> data;
+  OptimisticPatch(this.id, this.data);
+}
+
+class OptimisticProxy implements Cache {
+  OptimisticNormalizedInMemoryCache cache;
+  HashMap<String, dynamic> data = HashMap<String, dynamic>();
+  OptimisticProxy(this.cache);
+
+  @override
+  dynamic read(String key) {
+    if (data.containsKey(key)) {
+      return cache.denormalize(data[key]);
+    }
+    return cache.read(key);
+  }
+
+  @override
+  void write(String key, dynamic value) {
+    cache.writeInto(key, value, data);
+  }
+
+  // TODO should persistence be a seperate concern from caching
+  @override
+  void save() {}
+  @override
+  void restore() {}
+  @override
+  void reset() {}
+}
+
+typedef Cache CacheTransform(Cache proxy);
+
+class OptimisticNormalizedInMemoryCache extends NormalizedInMemoryCache {
+  @protected
+  List<OptimisticPatch> optimisticPatches = <OptimisticPatch>[];
+
+  /// Reads and dereferences an entity from the first valid optimistic layer,
+  /// defaulting to the base internal HashMap.
+  @override
+  dynamic read(String key) {
+    for (OptimisticPatch patch in optimisticPatches) {
+      if (patch.data.containsKey(key)) {
+        return denormalize(patch.data[key]);
+      }
+    }
+    return super.read(key);
+  }
+
+  OptimisticProxy get _proxy => OptimisticProxy(this);
+
+  void addOptimisiticPatch(
+    String addId,
+    CacheTransform transform,
+  ) {
+    final OptimisticProxy patch = transform(_proxy);
+    optimisticPatches.insert(0, OptimisticPatch(addId, patch.data));
+  }
+
+  void removeOptimisticPatch(String removeId) {
+    optimisticPatches.removeWhere(
+      (OptimisticPatch patch) => patch.id != removeId,
+    );
+  }
+}

--- a/lib/src/core/graphql_error.dart
+++ b/lib/src/core/graphql_error.dart
@@ -18,7 +18,7 @@ class Location {
 /// A GraphQL error (returned by a GraphQL server).
 class GraphQLError {
   GraphQLError({
-    this.data,
+    this.raw,
     this.message,
     this.locations,
     this.path,
@@ -26,20 +26,20 @@ class GraphQLError {
   });
 
   /// Constructs a [GraphQLError] from a JSON map.
-  GraphQLError.fromJSON(this.data)
-      : message = data['message'] as String,
-        locations = data['locations'] is List<Map<String, int>>
+  GraphQLError.fromJSON(this.raw)
+      : message = raw['message'] as String,
+        locations = raw['locations'] is List<Map<String, int>>
             ? List<Location>.from(
-                (data['locations'] as List<Map<String, int>>).map<Location>(
+                (raw['locations'] as List<Map<String, int>>).map<Location>(
                   (Map<String, int> location) => Location.fromJSON(location),
                 ),
               )
             : null,
-        path = data['path'] as List<dynamic>,
-        extensions = data['extensions'] as Map<String, dynamic>;
+        path = raw['path'] as List<dynamic>,
+        extensions = raw['extensions'] as Map<String, dynamic>;
 
   /// The message of the error.
-  final dynamic data;
+  final dynamic raw;
 
   /// The message of the error.
   final String message;

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -51,6 +51,32 @@ class ObservableQuery {
   Stream<QueryResult> get stream => controller.stream;
   bool get isCurrentlyPolling => lifecycle == QueryLifecycle.POLLING;
 
+  bool get _isRefetchSafe {
+    switch (lifecycle) {
+      case QueryLifecycle.COMPLETED:
+      case QueryLifecycle.POLLING:
+      case QueryLifecycle.POLLING_STOPPED:
+        return true;
+
+      case QueryLifecycle.PENDING:
+      case QueryLifecycle.CLOSED:
+      case QueryLifecycle.UNEXECUTED:
+      case QueryLifecycle.SIDE_EFFECTS_PENDING:
+      case QueryLifecycle.SIDE_EFFECTS_BLOCKING:
+        return false;
+    }
+    return false;
+  }
+
+  /// Attempts to refetch, returning `true` if successful
+  bool refetch() {
+    if (_isRefetchSafe) {
+      scheduler.refetchQuery(queryId);
+      return true;
+    }
+    return false;
+  }
+
   bool get isRebroadcastSafe {
     switch (lifecycle) {
       case QueryLifecycle.PENDING:

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -107,7 +107,6 @@ class ObservableQuery {
       StreamSubscription<QueryResult> subscription;
 
       subscription = stream.listen((QueryResult result) {
-        print([options.operationName, lifecycle]);
         void handle(OnData callback) {
           callback(result);
         }

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -107,6 +107,7 @@ class ObservableQuery {
       StreamSubscription<QueryResult> subscription;
 
       subscription = stream.listen((QueryResult result) {
+        print([options.operationName, lifecycle]);
         void handle(OnData callback) {
           callback(result);
         }

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -121,7 +121,7 @@ class ObservableQuery {
     // don't overwrite results due to some async/optimism issue
     if (previousResult != null &&
         previousResult.timestamp.isAfter(result.timestamp)) {
-      return null;
+      return;
     }
 
     if (previousResult != null) {
@@ -130,6 +130,7 @@ class ObservableQuery {
     }
 
     previousResult = result;
+
     controller.add(result);
   }
 
@@ -145,6 +146,7 @@ class ObservableQuery {
 
         if (!result.loading) {
           callbacks.forEach(handle);
+
           queryManager.rebroadcastQueries(optimistic: result.optimistic);
           if (!result.optimistic) {
             subscription.cancel();
@@ -189,7 +191,7 @@ class ObservableQuery {
     }
   }
 
-  void setVariables(Map<String, dynamic> variables) {
+  set variables(Map<String, dynamic> variables) {
     options.variables = variables;
   }
 
@@ -201,8 +203,10 @@ class ObservableQuery {
   ///
   /// Returns a `FutureOr` of the resultant lifecycle
   /// (`QueryLifecycle.SIDE_EFFECTS_BLOCKING | QueryLifecycle.CLOSED`)
-  FutureOr<QueryLifecycle> close(
-      {bool force = false, bool fromManager = false}) async {
+  FutureOr<QueryLifecycle> close({
+    bool force = false,
+    bool fromManager = false,
+  }) async {
     if (lifecycle == QueryLifecycle.SIDE_EFFECTS_PENDING && !force) {
       lifecycle = QueryLifecycle.SIDE_EFFECTS_BLOCKING;
       // stop closing because we're waiting on something
@@ -219,6 +223,7 @@ class ObservableQuery {
     }
 
     stopPolling();
+
     await controller.close();
 
     lifecycle = QueryLifecycle.CLOSED;

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -113,6 +113,7 @@ class ObservableQuery {
 
         if (!result.loading) {
           callbacks.forEach(handle);
+          queryManager.rebroadcastQueries(optimistic: false);
           subscription.cancel();
           _onDataSubscriptions.remove(subscription);
 
@@ -121,9 +122,6 @@ class ObservableQuery {
               lifecycle = QueryLifecycle.COMPLETED;
               close();
             }
-
-            lifecycle = QueryLifecycle.COMPLETED;
-            close();
           }
         }
       });

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -147,7 +147,7 @@ class ObservableQuery {
         if (!result.loading) {
           callbacks.forEach(handle);
 
-          queryManager.rebroadcastQueries(optimistic: result.optimistic);
+          queryManager.rebroadcastQueries();
           if (!result.optimistic) {
             subscription.cancel();
             _onDataSubscriptions.remove(subscription);

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -51,6 +51,31 @@ class ObservableQuery {
   Stream<QueryResult> get stream => controller.stream;
   bool get isCurrentlyPolling => lifecycle == QueryLifecycle.POLLING;
 
+  bool get _isRefetchSafe {
+    switch (lifecycle) {
+      case QueryLifecycle.COMPLETED:
+      case QueryLifecycle.POLLING:
+      case QueryLifecycle.POLLING_STOPPED:
+        return true;
+
+      case QueryLifecycle.PENDING:
+      case QueryLifecycle.UNEXECUTED:
+      case QueryLifecycle.SIDE_EFFECTS_PENDING:
+      case QueryLifecycle.SIDE_EFFECTS_BLOCKING:
+        return false;
+    }
+    return false;
+  }
+
+  /// Attempts to refetch, returning `true` if successful
+  bool refetch() {
+    if (_isRefetchSafe) {
+      scheduler.refetchQuery(queryId);
+      return true;
+    }
+    return false;
+  }
+
   bool get isRebroadcastSafe {
     switch (lifecycle) {
       case QueryLifecycle.PENDING:

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -51,31 +51,6 @@ class ObservableQuery {
   Stream<QueryResult> get stream => controller.stream;
   bool get isCurrentlyPolling => lifecycle == QueryLifecycle.POLLING;
 
-  bool get _isRefetchSafe {
-    switch (lifecycle) {
-      case QueryLifecycle.COMPLETED:
-      case QueryLifecycle.POLLING:
-      case QueryLifecycle.POLLING_STOPPED:
-        return true;
-
-      case QueryLifecycle.PENDING:
-      case QueryLifecycle.UNEXECUTED:
-      case QueryLifecycle.SIDE_EFFECTS_PENDING:
-      case QueryLifecycle.SIDE_EFFECTS_BLOCKING:
-        return false;
-    }
-    return false;
-  }
-
-  /// Attempts to refetch, returning `true` if successful
-  bool refetch() {
-    if (_isRefetchSafe) {
-      scheduler.refetchQuery(queryId);
-      return true;
-    }
-    return false;
-  }
-
   bool get isRebroadcastSafe {
     switch (lifecycle) {
       case QueryLifecycle.PENDING:

--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -5,7 +5,6 @@ import 'package:meta/meta.dart';
 import 'package:graphql_flutter/src/core/query_manager.dart';
 import 'package:graphql_flutter/src/core/query_options.dart';
 import 'package:graphql_flutter/src/core/query_result.dart';
-
 import 'package:graphql_flutter/src/scheduler/scheduler.dart';
 
 typedef OnData = void Function(QueryResult result);

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -64,7 +64,7 @@ class QueryManager {
   ) async {
     final ObservableQuery observableQuery = getQuery(queryId);
     // create a new operation to fetch
-    final Operation operation = Operation.fromOptions(observableQuery.options);
+    final Operation operation = Operation.fromOptions(options);
 
     FetchResult fetchResult;
     QueryResult queryResult;

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -92,9 +92,7 @@ class QueryManager {
           );
 
           // add the cache result to an observable query if it exists
-          if (observableQuery != null) {
-            observableQuery.addResult(queryResult);
-          }
+          observableQuery?.addResult(queryResult);
 
           if (options.fetchPolicy == FetchPolicy.cacheFirst ||
               options.fetchPolicy == FetchPolicy.cacheOnly) {
@@ -185,7 +183,10 @@ class QueryManager {
     return null;
   }
 
-  /// push changed data from cache to query streams
+  /// Push changed data from cache to query streams
+  ///
+  /// rebroadcast queries inherit `optimistic`
+  /// from the triggering state-change
   void rebroadcastQueries({bool optimistic}) {
     for (ObservableQuery query in queries.values) {
       if (query.isRebroadcastSafe) {

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -14,6 +14,7 @@ import 'package:graphql_flutter/src/link/operation.dart';
 import 'package:graphql_flutter/src/link/fetch_result.dart';
 
 import 'package:graphql_flutter/src/cache/cache.dart';
+import 'package:graphql_flutter/src/cache/optimistic.dart' show OptimisticCache;
 
 import 'package:graphql_flutter/src/utilities/get_from_ast.dart';
 
@@ -94,7 +95,7 @@ class QueryManager {
 
           queryResult = _mapFetchResultToQueryResult(fetchResult);
 
-          // add the result to an observable query if it exists
+          // add the cache result to an observable query if it exists
           if (observableQuery != null) {
             observableQuery.controller.add(queryResult);
           }
@@ -125,6 +126,12 @@ class QueryManager {
           operation.toKey(),
           fetchResult.data,
         );
+        if (cache is OptimisticCache) {
+          // allow optimistic data to overwrite server results
+          fetchResult.data = cache.read(
+            operation.toKey(),
+          );
+        }
       }
 
       if (fetchResult.data == null &&

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -187,7 +187,7 @@ class QueryManager {
   ///
   /// rebroadcast queries inherit `optimistic`
   /// from the triggering state-change
-  void rebroadcastQueries({bool optimistic}) {
+  void rebroadcastQueries() {
     for (ObservableQuery query in queries.values) {
       if (query.isRebroadcastSafe) {
         final dynamic cachedData = cache.read(query.options.toKey());
@@ -195,7 +195,6 @@ class QueryManager {
           query.addResult(
             _mapFetchResultToQueryResult(
               FetchResult(data: cachedData),
-              optimistic: optimistic,
             ),
           );
         }

--- a/lib/src/core/query_manager.dart
+++ b/lib/src/core/query_manager.dart
@@ -84,6 +84,8 @@ class QueryManager {
             data: cachedData,
           );
 
+          // we're rebroadcasting from cache,
+          // so don't override optimism
           queryResult = _mapFetchResultToQueryResult(
             fetchResult,
             loading: false,
@@ -140,6 +142,7 @@ class QueryManager {
       queryResult = _mapFetchResultToQueryResult(
         fetchResult,
         loading: false,
+        optimistic: false,
       );
     } catch (error) {
       String errorMessage;

--- a/lib/src/core/query_options.dart
+++ b/lib/src/core/query_options.dart
@@ -1,5 +1,6 @@
 import 'package:graphql_flutter/src/utilities/helpers.dart';
 import 'package:meta/meta.dart';
+import 'package:graphql_flutter/src/core/raw_operation_data.dart';
 
 /// [FetchPolicy] determines where the client may return a result from. The options are:
 /// - cacheFirst (default): return result from cache. Only fetch from network if cached result is not available.
@@ -26,21 +27,14 @@ enum ErrorPolicy {
 }
 
 /// Base options.
-class BaseOptions {
+class BaseOptions extends RawOperationData {
   BaseOptions({
-    @required this.document,
-    this.variables,
+    @required String document,
+    Map<String, dynamic> variables,
     this.fetchPolicy,
     this.errorPolicy,
     this.context,
-  });
-
-  /// A GraphQL document that consists of a single query to be sent down to the server.
-  String document;
-
-  /// A map going from variable name to variable value, where the variables are used
-  /// within the GraphQL query.
-  Map<String, dynamic> variables;
+  }) : super(document: document, variables: variables);
 
   /// Specifies the [FetchPolicy] to be used.
   FetchPolicy fetchPolicy;

--- a/lib/src/core/query_options.dart
+++ b/lib/src/core/query_options.dart
@@ -17,6 +17,17 @@ enum FetchPolicy {
   networkOnly,
 }
 
+// TODO investigate the relationship between optimistic results
+// and policy in flutter
+bool shouldRespondEagerlyFromCache(FetchPolicy fetchPolicy) =>
+    fetchPolicy == FetchPolicy.cacheFirst ||
+    fetchPolicy == FetchPolicy.cacheAndNetwork ||
+    fetchPolicy == FetchPolicy.cacheOnly;
+
+bool shouldStopAtCache(FetchPolicy fetchPolicy) =>
+    fetchPolicy == FetchPolicy.cacheFirst ||
+    fetchPolicy == FetchPolicy.cacheOnly;
+
 /// [ErrorPolicy] determines the level of events for errors in the execution result. The options are:
 /// - none (default): any errors from the request are treated like runtime errors and the observable is stopped.
 /// - ignore: errors from the request do not stop the observable, but also don't call `next`.
@@ -35,7 +46,11 @@ class BaseOptions extends RawOperationData {
     this.fetchPolicy,
     this.errorPolicy,
     this.context,
+    this.optimisticResult,
   }) : super(document: document, variables: variables);
+
+  /// An optimistic result to eagerly add to the operation stream
+  Object optimisticResult;
 
   /// Specifies the [FetchPolicy] to be used.
   FetchPolicy fetchPolicy;
@@ -54,6 +69,7 @@ class QueryOptions extends BaseOptions {
     Map<String, dynamic> variables,
     FetchPolicy fetchPolicy = FetchPolicy.cacheFirst,
     ErrorPolicy errorPolicy = ErrorPolicy.none,
+    Object optimisticResult,
     this.pollInterval,
     Map<String, dynamic> context,
   }) : super(
@@ -62,6 +78,7 @@ class QueryOptions extends BaseOptions {
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           context: context,
+          optimisticResult: optimisticResult,
         );
 
   /// The time interval (in milliseconds) on which this query should be
@@ -93,6 +110,7 @@ class WatchQueryOptions extends QueryOptions {
     Map<String, dynamic> variables,
     FetchPolicy fetchPolicy = FetchPolicy.cacheAndNetwork,
     ErrorPolicy errorPolicy = ErrorPolicy.none,
+    Object optimisticResult,
     int pollInterval,
     this.fetchResults,
     Map<String, dynamic> context,
@@ -103,6 +121,7 @@ class WatchQueryOptions extends QueryOptions {
           errorPolicy: errorPolicy,
           pollInterval: pollInterval,
           context: context,
+          optimisticResult: optimisticResult,
         );
 
   /// Whether or not to fetch result.

--- a/lib/src/core/query_options.dart
+++ b/lib/src/core/query_options.dart
@@ -1,5 +1,6 @@
-import 'package:graphql_flutter/src/utilities/helpers.dart';
 import 'package:meta/meta.dart';
+
+import 'package:graphql_flutter/src/utilities/helpers.dart';
 import 'package:graphql_flutter/src/core/raw_operation_data.dart';
 
 /// [FetchPolicy] determines where the client may return a result from. The options are:

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -6,6 +6,7 @@ class QueryResult {
     this.errors,
     this.loading,
     this.stale,
+    this.optimistic = false,
   });
 
   /// List<dynamic> or Map<String, dynamic>
@@ -13,6 +14,7 @@ class QueryResult {
   List<GraphQLError> errors;
   bool loading;
   bool stale;
+  bool optimistic;
 
   bool get hasErrors {
     if (errors == null) {

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -34,16 +34,4 @@ class QueryResult {
       errors = <GraphQLError>[graphQLError];
     }
   }
-
-  QueryResult withDependencyOn(QueryResult dependency) {
-    print(dependency.optimistic);
-    return QueryResult(
-      data: data,
-      errors: errors,
-      loading: loading,
-      stale: stale,
-      optimistic:
-          (dependency.optimistic == true) ? dependency.optimistic : optimistic,
-    )..timestamp = timestamp;
-  }
 }

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -34,4 +34,16 @@ class QueryResult {
       errors = <GraphQLError>[graphQLError];
     }
   }
+
+  QueryResult withDependencyOn(QueryResult dependency) {
+    print(dependency.optimistic);
+    return QueryResult(
+      data: data,
+      errors: errors,
+      loading: loading,
+      stale: stale,
+      optimistic:
+          (dependency.optimistic == true) ? dependency.optimistic : optimistic,
+    )..timestamp = timestamp;
+  }
 }

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -7,7 +7,9 @@ class QueryResult {
     this.loading,
     this.stale,
     this.optimistic = false,
-  });
+  }) : timestamp = DateTime.now();
+
+  DateTime timestamp;
 
   /// List<dynamic> or Map<String, dynamic>
   dynamic data;

--- a/lib/src/core/query_result.dart
+++ b/lib/src/core/query_result.dart
@@ -15,6 +15,7 @@ class QueryResult {
   dynamic data;
   List<GraphQLError> errors;
   bool loading;
+  // TODO not sure what this is for
   bool stale;
   bool optimistic;
 

--- a/lib/src/core/raw_operation_data.dart
+++ b/lib/src/core/raw_operation_data.dart
@@ -10,7 +10,9 @@ class RawOperationData {
   RawOperationData({
     @required this.document,
     Map<String, dynamic> variables,
-  }) : this.variables = SplayTreeMap<String, dynamic>.of(
+    String operationName,
+  })  : _operationName = operationName,
+        this.variables = SplayTreeMap<String, dynamic>.of(
           variables ?? const <String, dynamic>{},
         );
 

--- a/lib/src/core/raw_operation_data.dart
+++ b/lib/src/core/raw_operation_data.dart
@@ -1,0 +1,47 @@
+import 'dart:collection' show SplayTreeMap;
+import 'dart:convert' show json;
+import 'dart:io' show File;
+
+import 'package:meta/meta.dart';
+import 'package:graphql_flutter/src/utilities/get_from_ast.dart'
+    show getOperationName;
+
+class RawOperationData {
+  RawOperationData({
+    @required this.document,
+    Map<String, dynamic> variables,
+  }) : this.variables = SplayTreeMap<String, dynamic>.of(
+          variables ?? const <String, dynamic>{},
+        );
+
+  /// A GraphQL document that consists of a single query to be sent down to the server.
+  String document;
+
+  /// A map going from variable name to variable value, where the variables are used
+  /// within the GraphQL query.
+  Map<String, dynamic> variables;
+
+  String _operationName;
+
+  /// The last operation name appearing in the contained document.
+  String get operationName {
+    // XXX there is a bug in the `graphql_parser` package, where this result might be
+    // null event though the operation name is present in the document
+    _operationName ??= getOperationName(document);
+    _operationName ??= 'UNNAMED/' + document.hashCode.toString();
+    return _operationName;
+  }
+
+  String toKey() {
+    /// SplayTreeMap is always sorted
+    final String encodedVariables =
+        json.encode(variables, toEncodable: (dynamic object) {
+      if (object is File) {
+        return object.path;
+      }
+      return object;
+    });
+
+    return '$document|$encodedVariables|$operationName';
+  }
+}

--- a/lib/src/core/raw_operation_data.dart
+++ b/lib/src/core/raw_operation_data.dart
@@ -3,6 +3,7 @@ import 'dart:convert' show json;
 import 'dart:io' show File;
 
 import 'package:meta/meta.dart';
+
 import 'package:graphql_flutter/src/utilities/get_from_ast.dart'
     show getOperationName;
 

--- a/lib/src/link/fetch_result.dart
+++ b/lib/src/link/fetch_result.dart
@@ -1,10 +1,14 @@
 class FetchResult {
   FetchResult({
+    this.statusCode,
+    this.reasonPhrase,
     this.errors,
     this.data,
     this.extensions,
     this.context,
   });
+  int statusCode;
+  String reasonPhrase;
 
   List<dynamic> errors;
 

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -85,6 +85,7 @@ class HttpLink extends Link {
                 final BaseRequest request = await _prepareRequest(
                     uri, httpHeadersAndBody.body, httpHeaders);
 
+<<<<<<< HEAD
                 response = await fetcher.send(request);
 
                 operation.setContext(<String, StreamedResponse>{
@@ -92,6 +93,9 @@ class HttpLink extends Link {
                 });
                 final FetchResult parsedResponse =
                     await _parseResponse(response);
+=======
+                final FetchResult parsedResponse = _parseResponse(response);
+>>>>>>> don't hmm
 
                 controller.add(parsedResponse);
               } catch (error) {

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -14,6 +14,7 @@ import 'package:graphql_flutter/src/link/operation.dart';
 import 'package:graphql_flutter/src/link/fetch_result.dart';
 import 'package:graphql_flutter/src/link/http/fallback_http_config.dart';
 import 'package:graphql_flutter/src/link/http/http_config.dart';
+import 'package:graphql_flutter/src/utilities/helpers.dart' show notNull;
 
 class HttpLink extends Link {
   HttpLink({

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -85,7 +85,6 @@ class HttpLink extends Link {
                 final BaseRequest request = await _prepareRequest(
                     uri, httpHeadersAndBody.body, httpHeaders);
 
-<<<<<<< HEAD
                 response = await fetcher.send(request);
 
                 operation.setContext(<String, StreamedResponse>{
@@ -93,9 +92,6 @@ class HttpLink extends Link {
                 });
                 final FetchResult parsedResponse =
                     await _parseResponse(response);
-=======
-                final FetchResult parsedResponse = _parseResponse(response);
->>>>>>> don't hmm
 
                 controller.add(parsedResponse);
               } catch (error) {

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -14,7 +14,6 @@ import 'package:graphql_flutter/src/link/operation.dart';
 import 'package:graphql_flutter/src/link/fetch_result.dart';
 import 'package:graphql_flutter/src/link/http/fallback_http_config.dart';
 import 'package:graphql_flutter/src/link/http/http_config.dart';
-import 'package:rxdart/rxdart.dart';
 
 class HttpLink extends Link {
   HttpLink({
@@ -96,6 +95,7 @@ class HttpLink extends Link {
 
                 controller.add(parsedResponse);
               } catch (error) {
+                print(<dynamic>[error.runtimeType, error]);
                 controller.addError(error);
               }
 

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -301,7 +301,8 @@ Future<FetchResult> _parseResponse(StreamedResponse response) async {
   final FetchResult fetchResult = FetchResult();
 
   if (jsonResponse['errors'] != null) {
-    fetchResult.errors = jsonResponse['errors'] as List<dynamic>;
+    fetchResult.errors =
+        (jsonResponse['errors'] as List<dynamic>).where(notNull).toList();
   }
 
   if (jsonResponse['data'] != null) {

--- a/lib/src/link/http/link_http.dart
+++ b/lib/src/link/http/link_http.dart
@@ -9,12 +9,12 @@ import 'package:http_parser/http_parser.dart';
 import 'package:path/path.dart';
 import 'package:mime/mime.dart';
 
+import 'package:graphql_flutter/src/utilities/helpers.dart' show notNull;
 import 'package:graphql_flutter/src/link/link.dart';
 import 'package:graphql_flutter/src/link/operation.dart';
 import 'package:graphql_flutter/src/link/fetch_result.dart';
 import 'package:graphql_flutter/src/link/http/fallback_http_config.dart';
 import 'package:graphql_flutter/src/link/http/http_config.dart';
-import 'package:graphql_flutter/src/utilities/helpers.dart' show notNull;
 
 class HttpLink extends Link {
   HttpLink({

--- a/lib/src/link/operation.dart
+++ b/lib/src/link/operation.dart
@@ -1,19 +1,20 @@
-import 'dart:collection' show SplayTreeMap;
-import 'dart:convert' show json;
-import 'dart:io' show File;
+import 'package:meta/meta.dart';
+import 'package:graphql_flutter/src/core/raw_operation_data.dart';
 
-class Operation {
+class Operation extends RawOperationData {
   Operation({
-    this.document,
+    @required String document,
     Map<String, dynamic> variables,
-    this.operationName,
     this.extensions,
-  }) : this.variables =
-            SplayTreeMap<String, dynamic>.of(variables ?? <String, dynamic>{});
+  }) : super(document: document, variables: variables);
 
-  final String document;
-  final SplayTreeMap<String, dynamic> variables;
-  final String operationName;
+  factory Operation.fromOptions(RawOperationData options) {
+    return Operation(
+      document: options.document,
+      variables: options.variables,
+    );
+  }
+
   final Map<String, dynamic> extensions;
 
   final Map<String, dynamic> _context = <String, dynamic>{};
@@ -30,20 +31,8 @@ class Operation {
     return result;
   }
 
+  // operationName should never be null, but leaving this check in anyways
   bool get isSubscription =>
       operationName != null &&
       document.contains(RegExp(r'.*?subscription ' + operationName));
-
-  String toKey() {
-    /// SplayTreeMap is always sorted
-    final String encodedVariables =
-        json.encode(variables, toEncodable: (dynamic object) {
-      if (object is File) {
-        return object.path;
-      }
-      return object;
-    });
-
-    return '$document|$encodedVariables|$operationName';
-  }
 }

--- a/lib/src/link/operation.dart
+++ b/lib/src/link/operation.dart
@@ -6,7 +6,11 @@ class Operation extends RawOperationData {
     @required String document,
     Map<String, dynamic> variables,
     this.extensions,
-  }) : super(document: document, variables: variables);
+    String operationName,
+  }) : super(
+            document: document,
+            variables: variables,
+            operationName: operationName);
 
   factory Operation.fromOptions(RawOperationData options) {
     return Operation(

--- a/lib/src/link/operation.dart
+++ b/lib/src/link/operation.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+
 import 'package:graphql_flutter/src/core/raw_operation_data.dart';
 
 class Operation extends RawOperationData {

--- a/lib/src/scheduler/scheduler.dart
+++ b/lib/src/scheduler/scheduler.dart
@@ -57,10 +57,12 @@ class QueryScheduler {
     }
 
     // fetch each query on the interval
-    for (String queryId in intervalQueries[interval]) {
-      final WatchQueryOptions options = registeredQueries[queryId];
-      queryManager.fetchQuery(queryId, options);
-    }
+    intervalQueries[interval].forEach(refetchQuery);
+  }
+
+  void refetchQuery(String queryId) {
+    final WatchQueryOptions options = registeredQueries[queryId];
+    queryManager.fetchQuery(queryId, options);
   }
 
   void startPollingQuery(

--- a/lib/src/scheduler/scheduler.dart
+++ b/lib/src/scheduler/scheduler.dart
@@ -57,12 +57,10 @@ class QueryScheduler {
     }
 
     // fetch each query on the interval
-    intervalQueries[interval].forEach(refetchQuery);
-  }
-
-  void refetchQuery(String queryId) {
-    final WatchQueryOptions options = registeredQueries[queryId];
-    queryManager.fetchQuery(queryId, options);
+    for (String queryId in intervalQueries[interval]) {
+      final WatchQueryOptions options = registeredQueries[queryId];
+      queryManager.fetchQuery(queryId, options);
+    }
   }
 
   void startPollingQuery(

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -171,6 +171,7 @@ class MutationState extends State<Mutation> {
       key: Key(observableQuery?.options?.toKey()),
       initialData: QueryResult(
         loading: false,
+        optimistic: false,
       ),
       stream: observableQuery?.stream,
       builder: (

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -89,9 +89,6 @@ class MutationState extends State<Mutation> {
         widget.update(cache, result);
         if (cache is OptimisticCache) {
           cache.removeOptimisticPatch(mutationId);
-          observableQuery.queryManager.rebroadcastQueries(
-            optimistic: false,
-          );
         }
       }
 
@@ -117,6 +114,7 @@ class MutationState extends State<Mutation> {
           cache,
           QueryResult(
             loading: true,
+            optimistic: true,
             data: optimisticResult,
           ),
         );

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -148,7 +148,7 @@ class MutationState extends State<Mutation> {
 
   void runMutation(Map<String, dynamic> variables, {Object optimisticResult}) {
     observableQuery
-      ..setVariables(variables)
+      ..variables = variables
       ..onData(callbacks) // add callbacks to observable
       ..addResult(QueryResult(loading: true))
       ..fetchResults();
@@ -165,6 +165,10 @@ class MutationState extends State<Mutation> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<QueryResult>(
+      // we give the stream builder a key so that
+      // toggling mutations at the same place in the tree,
+      // such as is done in the example, won't result in bugs
+      key: Key(observableQuery?.options?.toKey()),
       initialData: QueryResult(
         loading: false,
       ),

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -89,6 +89,9 @@ class MutationState extends State<Mutation> {
         widget.update(cache, result);
         if (cache is OptimisticCache) {
           cache.removeOptimisticPatch(mutationId);
+          observableQuery.queryManager.rebroadcastQueries(
+            optimistic: false,
+          );
         }
       }
 
@@ -119,6 +122,9 @@ class MutationState extends State<Mutation> {
         );
         return cache;
       });
+      observableQuery.queryManager.rebroadcastQueries(
+        optimistic: true,
+      );
     }
   }
 
@@ -126,7 +132,7 @@ class MutationState extends State<Mutation> {
     observableQuery
       ..setVariables(variables)
       ..onData(callbacks) // add callbacks to observable
-      ..sendLoading()
+      ..addResult(QueryResult(loading: true))
       ..fetchResults();
 
     handleOptimism(optimisticResult);

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -81,10 +81,15 @@ class MutationState extends State<Mutation> {
     }
   }
 
-  void onCompleted(QueryResult result) {
-    if (!result.loading && !result.optimistic) {
-      widget.onCompleted(result.data);
+  OnData get onCompleted {
+    if (widget.onCompleted != null) {
+      return (QueryResult result) {
+        if (!result.loading && !result.optimistic) {
+          widget.onCompleted(result.data);
+        }
+      };
     }
+    return null;
   }
 
   void _optimisticUpdate(QueryResult result) {

--- a/lib/src/widgets/mutation.dart
+++ b/lib/src/widgets/mutation.dart
@@ -138,9 +138,8 @@ class MutationState extends State<Mutation> {
 
   // callbacks will be called against each result in the stream,
   // which should then rebroadcast queries with the appropriate optimism
-  Iterable<OnData> get callbacks {
-    return <OnData>[onCompleted, update].where(notNull);
-  }
+  Iterable<OnData> get callbacks =>
+      <OnData>[onCompleted, update].where(notNull);
 
   void runMutation(Map<String, dynamic> variables, {Object optimisticResult}) {
     observableQuery

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -7,7 +7,10 @@ import 'package:graphql_flutter/src/core/query_result.dart';
 
 import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 
-typedef QueryBuilder = Widget Function(QueryResult result);
+typedef QueryBuilder = Widget Function(
+  QueryResult result, {
+  VoidCallback refetch,
+});
 
 /// Builds a [Query] widget based on the a given set of [QueryOptions]
 /// that streams [QueryResult]s into the [QueryBuilder].
@@ -87,7 +90,10 @@ class QueryState extends State<Query> {
         BuildContext buildContext,
         AsyncSnapshot<QueryResult> snapshot,
       ) {
-        return widget?.builder(snapshot.data);
+        return widget?.builder(
+          snapshot.data,
+          refetch: observableQuery.refetch,
+        );
       },
     );
   }

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -7,10 +7,7 @@ import 'package:graphql_flutter/src/core/query_result.dart';
 
 import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 
-typedef QueryBuilder = Widget Function(
-  QueryResult result, {
-  VoidCallback refetch,
-});
+typedef QueryBuilder = Widget Function(QueryResult result);
 
 /// Builds a [Query] widget based on the a given set of [QueryOptions]
 /// that streams [QueryResult]s into the [QueryBuilder].
@@ -90,10 +87,7 @@ class QueryState extends State<Query> {
         BuildContext buildContext,
         AsyncSnapshot<QueryResult> snapshot,
       ) {
-        return widget?.builder(
-          snapshot.data,
-          refetch: observableQuery.refetch,
-        );
+        return widget?.builder(snapshot.data);
       },
     );
   }

--- a/lib/src/widgets/query.dart
+++ b/lib/src/widgets/query.dart
@@ -46,6 +46,7 @@ class QueryState extends State<Query> {
       pollInterval: widget.options.pollInterval,
       fetchResults: true,
       context: widget.options.context,
+      optimisticResult: widget.options.optimisticResult,
     );
   }
 

--- a/lib/src/widgets/subscription.dart
+++ b/lib/src/widgets/subscription.dart
@@ -49,9 +49,10 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
     final GraphQLClient client = GraphQLProvider.of(context).value;
     assert(client != null);
     final Operation operation = Operation(
-        document: widget.query,
-        variables: widget.variables,
-        operationName: widget.operationName);
+      document: widget.query,
+      variables: widget.variables,
+      operationName: widget.operationName,
+    );
 
     final Stream<FetchResult> stream = client.subscribe(operation);
 

--- a/lib/src/widgets/subscription.dart
+++ b/lib/src/widgets/subscription.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
+
 import 'package:graphql_flutter/src/graphql_client.dart';
 import 'package:graphql_flutter/src/link/fetch_result.dart';
 import 'package:graphql_flutter/src/link/operation.dart';
 import 'package:graphql_flutter/src/utilities/helpers.dart';
 import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
-
-import '../websocket/messages.dart';
+import 'package:graphql_flutter/src/websocket/messages.dart';
 
 typedef OnSubscriptionCompleted = void Function();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,4 +28,4 @@ dev_dependencies:
   test: ^1.3.0
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"

--- a/test/graphql_flutter_test.dart
+++ b/test/graphql_flutter_test.dart
@@ -253,8 +253,9 @@ void main() {
         expectContinuationString(bodyBytes, boundary);
         expectContinuationString(bodyBytes,
             '\r\ncontent-disposition: form-data; name="operations"\r\n\r\n');
+        // operationName of unamed operations is "UNNAMED/" +  document.hashCode.toString()
         expectContinuationString(bodyBytes,
-            r'{"operationName":null,"variables":{"files":[null,null]},"query":"    mutation($files: [Upload!]!) {\n      multipleUpload(files: $files) {\n        id\n        filename\n        mimetype\n        path\n      }\n    }\n    "}');
+            r'{"operationName":"UNNAMED/596708007","variables":{"files":[null,null]},"query":"    mutation($files: [Upload!]!) {\n      multipleUpload(files: $files) {\n        id\n        filename\n        mimetype\n        path\n      }\n    }\n    "}');
         expectContinuationString(bodyBytes, '\r\n--');
         expectContinuationString(bodyBytes, boundary);
         expectContinuationString(bodyBytes,

--- a/test/graphql_flutter_test.dart
+++ b/test/graphql_flutter_test.dart
@@ -2,10 +2,11 @@ import 'dart:convert';
 import 'dart:io' show File, Platform;
 import 'dart:typed_data' show Uint8List;
 
-import 'package:path/path.dart' show dirname, join;
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:path/path.dart' show dirname, join;
 import 'package:http/http.dart' as http;
+
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 class MockHttpClient extends Mock implements http.Client {}

--- a/test/normalized_in_memory_test.dart
+++ b/test/normalized_in_memory_test.dart
@@ -177,9 +177,9 @@ void main() {
     );
     test('lazily reads cyclical references', () {
       cache.write(rawOperationKey, cyclicalOperationData);
-      final LazyMap a = cache.read('A/1');
+      final LazyMap a = cache.read('A/1') as LazyMap;
       expect(a.data, equals(cyclicalNormalizedA));
-      final LazyMap b = a['b'];
+      final LazyMap b = a['b'] as LazyMap;
       expect(b.data, equals(cyclicalNormalizedB));
     });
   });

--- a/test/normalized_in_memory_test.dart
+++ b/test/normalized_in_memory_test.dart
@@ -178,9 +178,9 @@ void main() {
     );
     test('lazily reads cyclical references', () {
       cache.write(rawOperationKey, cyclicalOperationData);
-      final LazyMap a = cache.read('A/1') as LazyMap;
+      final LazyCacheMap a = cache.read('A/1') as LazyCacheMap;
       expect(a.data, equals(cyclicalNormalizedA));
-      final LazyMap b = a['b'] as LazyMap;
+      final LazyCacheMap b = a['b'] as LazyCacheMap;
       expect(b.data, equals(cyclicalNormalizedB));
     });
   });

--- a/test/normalized_in_memory_test.dart
+++ b/test/normalized_in_memory_test.dart
@@ -1,4 +1,5 @@
 import 'package:test/test.dart';
+
 import 'package:graphql_flutter/src/cache/normalized_in_memory.dart';
 import 'package:graphql_flutter/src/cache/lazy_cache_map.dart';
 


### PR DESCRIPTION
closes #127
closes #190 

This is a pretty big change. I threw in some other smaller stuff (`refetch`, `rebroadcastQueries`), but the main thing is that this implements:
* an `OptimisticCache`, which maintains a stack of patches for tracking optimistic state
  * patches can be heirachical, and this is taken advantage of by `Mutation#update`:
    > The optimistic cache layer id `update` will write to
    > is a "child patch" of the default optimistic patch
    > created by the query manager
* a `LazyCacheMap` that handles lazy dereferencing from the cache, as well as track the optimistic state of entities in the cache


### Breaking changes

- Broke `onCompleted` signature because it didn't match apollo's and is only called when `data` is ready.
- Moved `_inMemoryCache` to `@protected data` for testing/override purposes (important for `OptimisticPatches`
- Updated the example to use optimism
- adds a `refetch` argument to the `Query` `builder`

#### Fixes / Enhancements

- Added `OptimisticCache` and related attributes to `QueryResult` (`optimistic`, `timestamp`) 
- Added `lazy_cache_map.dart` for handling cyclical dereferences in the normalized cache
  - added `CacheState` for tracking optimism from the perspective of normalized cache entities
- Added `raw_operation_data.dart` to consolidate base functionality
- Added `rebroadcastQueries` to the `QueryManager`, for use post-update, which rebroadcasts all "safe" queries that can be with updated data from the cache
- Added `optimisticResult` management to the `QueryManager`
- Added `optimisticResult` to `BaseOptions`, and `QueryOptoins` (it is added in `runMutation` for mutations)
- Added `optimistic` attribute `QueryResult` itself for lifecycle management. 

#### Docs
* `LazyCacheMap` usage and reasoning
*  Optimism section. differences between `result.optimistic` and `LazyCacheMap.isOptimistic`
* `update`, `onCompleted` usage/existence
* `refetch` usage/existence


Optimism should still be considered experimental. The biggest question requiring further investigation is what the relationship between `FetchPolicy` and optimism is in apollo.

To give a more detailed survey of how optimism works in a `mutation` update situation:
* if provided to `runMutation`, an `optimisticResult` is added to `QueryOptions`
* this is handled by the `QueryManager`, which then:
  * writes the optimistic data as a patch with the id `$queryId` to the `OptimisticCache`
  * adds a wrapping `optimistic` `QueryResult` to the query stream
* this result is seen by `onData` in `ObservableQuery`, which then:
  * if `update` is provided to the mutation, it's patch is recorded as `$queryId.update`
  * queryies are rebroadcast (even if there was no operation provided, because underlying data could have changed)
* UI is updated
* real results are received
  * Patches beginning with `$queryId` are discarded 
  * new results are added to the stream
  * listeners are cleaned up


With minor changes (`optimisticResult` added in `QueryOptions` constructor, no `update`, `Query`'s optimistic behavoir _should_ be similar, though the component __does not__ call `onData`, so other queries are not automatically rebroadcast. __I think the rebroadcast behavoir needs more attention__ in another future PR.

