### PR TITLE
Check operationName before constructing regex in Operation.isSubscription, fixes #186

### DIFF
--- a/lib/src/link/operation.dart
+++ b/lib/src/link/operation.dart
@@ -29,7 +29,9 @@ class Operation {
     return result;
   }
 
-  bool get isSubscription => document.contains(RegExp(r'.*?subscription ' + operationName));
+  bool get isSubscription =>
+      operationName != null &&
+      document.contains(RegExp(r'.*?subscription ' + operationName));
 
   String toKey() {
     /// SplayTreeMap is always sorted


### PR DESCRIPTION
On the `next` branch, manual mutations fail because of the newly added isSubscription getter throwing an exception if operationName is null (which seems to be the case for non-subscriptions). Adding a nullcheck fixes the issue (at least for me) when using `GraphQLClient.mutate`.

Fixes https://github.com/zino-app/graphql-flutter/issues/186