### PR TITLE
Fix null variables in QueryOptions causing exception in Operation constructor

### DIFF
--- a/lib/src/link/operation.dart
+++ b/lib/src/link/operation.dart
@@ -8,7 +8,8 @@ class Operation {
     Map<String, dynamic> variables,
     this.operationName,
     this.extensions,
-  }) : this.variables = SplayTreeMap<String, dynamic>.of(variables);
+  }) : this.variables =
+            SplayTreeMap<String, dynamic>.of(variables ?? <String, dynamic>{});
 
   final String document;
   final SplayTreeMap<String, dynamic> variables;


### PR DESCRIPTION
As it says on the tin - that said, it might be worth doing this at a higher level (e.g. QueryOptions) to avoid having to special-case other places in the future. This change, along with https://github.com/zino-app/graphql-flutter/pull/210, makes an app that worked with the https://github.com/snowballdigital/flutter-graphql fork also work with the changes in the `next` branch.