### PR TITLE
disable polling when interval is set to zero

### DIFF
--- a/lib/src/core/observable_query.dart
+++ b/lib/src/core/observable_query.dart
@@ -67,7 +67,7 @@ class ObservableQuery {
         ? QueryLifecycle.SIDE_EFFECTS_PENDING
         : QueryLifecycle.PENDING;
 
-    if (options.pollInterval != null) {
+    if (options.pollInterval != null && options.pollInterval > 0) {
       startPolling(options.pollInterval);
     }
   }

--- a/lib/src/scheduler/scheduler.dart
+++ b/lib/src/scheduler/scheduler.dart
@@ -69,6 +69,11 @@ class QueryScheduler {
   ) {
     registeredQueries[queryId] = options;
 
+    // if interval is 0, then polling should be disabled
+    if (options.pollInterval == 0) {
+      return;
+    }
+
     final Duration interval = Duration(
       seconds: options.pollInterval,
     );

--- a/lib/src/scheduler/scheduler.dart
+++ b/lib/src/scheduler/scheduler.dart
@@ -67,12 +67,9 @@ class QueryScheduler {
     WatchQueryOptions options,
     String queryId,
   ) {
-    registeredQueries[queryId] = options;
+    assert(options.pollInterval != null && options.pollInterval > 0);
 
-    // if interval is 0, then polling should be disabled
-    if (options.pollInterval == 0) {
-      return;
-    }
+    registeredQueries[queryId] = options;
 
     final Duration interval = Duration(
       seconds: options.pollInterval,


### PR DESCRIPTION
Disables polling interval when set to zero, this caused it to poll the GraphQL server nonstop. 

#### Fixes / Enhancements

- Added a check at startPollingQuery method to check whether polling is zero, if zero, it doesn't register it for polling
