### PR TITLE
update docs example - cast httplink as Link and async in the wrong lo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,12 @@ void main() {
   );
 
   final AuthLink authLink = AuthLink(
-    getToken: () => async 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
+    getToken: () async => 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
+    // OR
+    // getToken: () => 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
   );
 
-  final Link link = authLink.concat(httpLink);
+  final Link link = authLink.concat(httpLink as Link);
 
   ValueNotifier<GraphQLClient> client = ValueNotifier(
     GraphQLClient(


### PR DESCRIPTION
Based on the current stable, the docs are outdated, with the example showing how to connect to the GitHub GraphQL endpoint.

```dart
...
final AuthLink authLink = AuthLink(
  getToken: () => async 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
);

final Link link = authLink.concat(httpLink);
...
```

This needs to change to in the docs:

```dart
final AuthLink authLink = AuthLink(
  getToken: () async => 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
);

final Link link = authLink.concat(httpLink as Link);
```