### PR TITLE
Unwrap lazy dereferences in merge all, clean up linting and print statements

### DIFF
--- a/example/lib/graphql_widget/main.dart
+++ b/example/lib/graphql_widget/main.dart
@@ -115,7 +115,6 @@ class _MyHomePageState extends State<MyHomePage> {
                       'Both data and errors are null, this is a known bug after refactoring, you might forget to set Github token');
                 }
 
-                print(result.data is LazyCacheMap);
                 // result.data can be either a [List<dynamic>] or a [Map<String, dynamic>]
                 final List<LazyCacheMap> repositories = (result.data['viewer']
                         ['repositories']['nodes'] as List<dynamic>)
@@ -184,7 +183,6 @@ class StarrableRepository extends StatelessWidget {
         document: starred ? mutations.removeStar : mutations.addStar,
       ),
       builder: (RunMutation toggleStar, QueryResult result) {
-        print(<bool>[result.loading, optimistic]);
         return ListTile(
           leading: starred
               ? const Icon(
@@ -214,7 +212,6 @@ class StarrableRepository extends StatelessWidget {
               Map<String, Object>.from(repository)
                 ..addAll(extractRepositoryData(result.data));
           cache.write(typenameDataIdFromObject(updated), updated);
-          print(cache.read(typenameDataIdFromObject(updated)).isOptimistic);
         }
       },
       onCompleted: (dynamic resultData) {

--- a/lib/src/cache/lazy_cache_map.dart
+++ b/lib/src/cache/lazy_cache_map.dart
@@ -35,9 +35,16 @@ class LazyCacheMap extends LazyDereferencingMap {
   }
 }
 
+/// Unwrap a given Object that could possibly be a lazy map
 Object unwrap(Object possibleLazyMap) => possibleLazyMap is LazyDereferencingMap
     ? possibleLazyMap.data
     : possibleLazyMap;
+
+/// Unwrap a given mpa that could possibly be a lazy map
+Map<String, Object> unwrapMap(Map<String, Object> possibleLazyMap) =>
+    possibleLazyMap is LazyDereferencingMap
+        ? possibleLazyMap.data
+        : possibleLazyMap;
 
 /// A simple map wrapper that lazily dereferences using `dereference`
 ///
@@ -55,7 +62,7 @@ class LazyDereferencingMap implements Map<String, Object> {
 
   final Map<String, Object> _data;
 
-  /// get the warpped `Map` without dereferencing
+  /// get the wrapped `Map` without dereferencing
   Map<String, Object> get data => _data;
 
   @protected

--- a/lib/src/cache/optimistic.dart
+++ b/lib/src/cache/optimistic.dart
@@ -145,11 +145,5 @@ class OptimisticCache extends NormalizedInMemoryCache {
       (OptimisticPatch patch) =>
           patch.id == removeId || _parentPatchId(patch.id) == removeId,
     );
-
-    print(<dynamic>[
-      optimisticPatches.length,
-      optimisticPatches.map<String>((OptimisticPatch p) => p.id),
-      removeId
-    ]);
   }
 }

--- a/lib/src/socket_client.dart
+++ b/lib/src/socket_client.dart
@@ -107,7 +107,7 @@ class SocketClient {
           .map<GraphQLSocketMessage>(_parseSocketMessage);
 
       if (config.inactivityTimeout != null) {
-        _keepAliveSubscription = _connectionKeepAlive.timeout(
+        _keepAliveSubscription = _messagesOfType<ConnectionKeepAlive>().timeout(
           config.inactivityTimeout,
           onTimeout: (EventSink<ConnectionKeepAlive> event) {
             print(
@@ -332,19 +332,13 @@ class SocketClient {
   Stream<SocketConnectionState> get connectionState =>
       _connectionStateController.stream;
 
-  Stream<ConnectionAck> get _connectionAck => _messageStream
-      .where((GraphQLSocketMessage message) => message is ConnectionAck)
-      .cast<ConnectionAck>();
-
-  Stream<ConnectionError> get _connectionError => _messageStream
-      .where((GraphQLSocketMessage message) => message is ConnectionError)
-      .cast<ConnectionError>();
-
-  Stream<ConnectionKeepAlive> get _connectionKeepAlive => _messageStream
-      .where((GraphQLSocketMessage message) => message is ConnectionKeepAlive)
-      .cast<ConnectionKeepAlive>();
-
-  Stream<UnknownData> get _unknownData => _messageStream
-      .where((GraphQLSocketMessage message) => message is UnknownData)
-      .cast<UnknownData>();
+  /// Filter `_messageStream` for messages of the given type of [GraphQLSocketMessage]
+  ///
+  /// Example usages:
+  /// `_messagesOfType<ConnectionAck>()` for init acknowledgments
+  /// `_messagesOfType<ConnectionError>()` for errors
+  /// `_messagesOfType<UnknownData>()` for unknown data messages
+  Stream<M> _messagesOfType<M extends GraphQLSocketMessage>() => _messageStream
+      .where((GraphQLSocketMessage message) => message is M)
+      .cast<M>();
 }

--- a/lib/src/utilities/helpers.dart
+++ b/lib/src/utilities/helpers.dart
@@ -1,3 +1,6 @@
+import 'package:graphql_flutter/src/cache/lazy_cache_map.dart'
+    show LazyDereferencingMap, unwrapMap;
+
 bool notNull(Object any) {
   return any != null;
 }
@@ -33,6 +36,8 @@ Map<String, dynamic> _recursivelyAddAll(
   Map<String, dynamic> target,
   Map<String, dynamic> source,
 ) {
+  target = unwrapMap(target);
+  source = unwrapMap(source);
   source.forEach((String key, dynamic value) {
     if (target.containsKey(key) &&
         target[key] is Map &&
@@ -61,6 +66,7 @@ Map<String, dynamic> _recursivelyAddAll(
 /// // { keyA: a2, keyB: b3 }
 /// ```
 ///
+/// All given [LazyDereferencingMap] instances will be unwrapped
 Map<String, dynamic> deeplyMergeLeft(
   Iterable<Map<String, dynamic>> maps,
 ) {

--- a/lib/src/websocket/messages.dart
+++ b/lib/src/websocket/messages.dart
@@ -155,7 +155,8 @@ class ConnectionKeepAlive extends GraphQLSocketMessage {
 /// payload. The user should check the errors result before processing the
 /// data value. These error are from the query resolvers.
 class SubscriptionData extends GraphQLSocketMessage {
-  SubscriptionData(this.id, this.data, this.errors) : super(MessageTypes.GQL_DATA);
+  SubscriptionData(this.id, this.data, this.errors)
+      : super(MessageTypes.GQL_DATA);
 
   final String id;
   final dynamic data;


### PR DESCRIPTION
Mostly just fixing lint errors and removing print statements 😅 

Also patching a stack overflow issue from normalization by unwrapping lazy dereferences in `deeplyMergeLeft`