### PR TITLE
Fix issue #238. Compile error on Flutter 1.5.5

### DIFF
--- a/lib/src/widgets/subscription.dart
+++ b/lib/src/widgets/subscription.dart
@@ -12,9 +12,9 @@ import 'package:graphql_flutter/src/websocket/messages.dart';
 typedef OnSubscriptionCompleted = void Function();
 
 typedef SubscriptionBuilder<T> = Widget Function({
-  final bool loading,
-  final T payload,
-  final dynamic error,
+  bool loading,
+  T payload,
+  dynamic error,
 });
 
 class Subscription<T> extends StatefulWidget {


### PR DESCRIPTION
Fix issue #238.

#### Fixes / Enhancements

- Fixed the compile error on Flutter 1.5.5. The error was the `final` keyword on `SubscriptionBuilder` typedef.
