### PR TITLE
ci: ignore lint and coverage steps for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,13 +202,13 @@ workflows:
             - dependencies
           filters:
             tags:
-              only: /^.*$/
+              ignore: /^.*$/
       - coverage:
           requires:
             - dependencies
           filters:
             tags:
-              only: /^.*$/
+              ignore: /^.*$/
       - release:
           requires:
             - dependencies
@@ -228,9 +228,7 @@ workflows:
                 - master
       - publish:
           requires:
-            - dependencies
-            - lint
-            - coverage        
+            - dependencies 
           filters:
             tags:
               only: /^.*$/


### PR DESCRIPTION
This PR removes the `lint` and `coverage` steps from workflows triggered by a git tag. The idea behind it is that the code is already linted and tested before the tag was released. Therefore the linting and testing is redundant.