### PR TITLE
Handle Anonymous ops

### DIFF
--- a/packages/graphql/lib/src/core/raw_operation_data.dart
+++ b/packages/graphql/lib/src/core/raw_operation_data.dart
@@ -24,14 +24,20 @@ class RawOperationData {
   Map<String, dynamic> variables;
 
   String _operationName;
+  String _documentIdentifier;
 
   /// The last operation name appearing in the contained document.
   String get operationName {
     // XXX there is a bug in the `graphql_parser` package, where this result might be
     // null event though the operation name is present in the document
     _operationName ??= getOperationName(document);
-    _operationName ??= 'UNNAMED/' + document.hashCode.toString();
     return _operationName;
+  }
+
+  String get _identifier {
+    _documentIdentifier ??=
+        operationName ?? 'UNNAMED/' + document.hashCode.toString();
+    return _documentIdentifier;
   }
 
   String toKey() {
@@ -44,6 +50,6 @@ class RawOperationData {
       return object;
     });
 
-    return '$document|$encodedVariables|$operationName';
+    return '$document|$encodedVariables|$_identifier';
   }
 }

--- a/packages/graphql/lib/src/link/operation.dart
+++ b/packages/graphql/lib/src/link/operation.dart
@@ -36,7 +36,6 @@ class Operation extends RawOperationData {
     return result;
   }
 
-  // operationName should never be null, but leaving this check in anyways
   bool get isSubscription =>
       operationName != null &&
       document.contains(RegExp(r'.*?subscription ' + operationName));

--- a/packages/graphql/test/anonymous_operations_test.dart
+++ b/packages/graphql/test/anonymous_operations_test.dart
@@ -1,3 +1,4 @@
+// copy/pasted from ./graphql_client_test.dart
 import 'dart:typed_data' show Uint8List;
 
 import 'package:test/test.dart';
@@ -11,10 +12,9 @@ import './helpers.dart';
 class MockHttpClient extends Mock implements http.Client {}
 
 void main() {
-  const String readRepositories = r'''
-  query ReadRepositories($nRepositories: Int!) {
+  const String readRepositories = r'''{
     viewer {
-      repositories(last: $nRepositories) {
+      repositories(last: 42) {
         nodes {
           __typename
           id
@@ -26,9 +26,8 @@ void main() {
   }
 ''';
 
-  const String addStar = r'''
-  mutation AddStar($starrableId: ID!) {
-    action: addStar(input: {starrableId: $starrableId}) {
+  const String addStar = r'''mutation {
+    action: addStar(input: {starrableId: "some_repo"}) {
       starrable {
         viewerHasStarred
       }
@@ -63,9 +62,7 @@ void main() {
       test('successful query', () async {
         final WatchQueryOptions _options = WatchQueryOptions(
           document: readRepositories,
-          variables: <String, dynamic>{
-            'nRepositories': 42,
-          },
+          variables: <String, dynamic>{},
         );
         when(
           mockHttpClient.send(any),
@@ -117,7 +114,7 @@ void main() {
           },
         );
         expect(await capt.finalize().bytesToString(),
-            r'{"operationName":"ReadRepositories","variables":{"nRepositories":42},"query":"  query ReadRepositories($nRepositories: Int!) {\n    viewer {\n      repositories(last: $nRepositories) {\n        nodes {\n          __typename\n          id\n          name\n          viewerHasStarred\n        }\n      }\n    }\n  }\n"}');
+            r'{"operationName":null,"variables":{},"query":"{\n    viewer {\n      repositories(last: 42) {\n        nodes {\n          __typename\n          id\n          name\n          viewerHasStarred\n        }\n      }\n    }\n  }\n"}');
 
         expect(r.errors, isNull);
         expect(r.data, isNotNull);
@@ -163,7 +160,7 @@ void main() {
           },
         );
         expect(await request.finalize().bytesToString(),
-            r'{"operationName":"AddStar","variables":{},"query":"  mutation AddStar($starrableId: ID!) {\n    action: addStar(input: {starrableId: $starrableId}) {\n      starrable {\n        viewerHasStarred\n      }\n    }\n  }\n"}');
+            r'{"operationName":null,"variables":{},"query":"mutation {\n    action: addStar(input: {starrableId: \"some_repo\"}) {\n      starrable {\n        viewerHasStarred\n      }\n    }\n  }\n"}');
 
         expect(response.errors, isNull);
         expect(response.data, isNotNull);

--- a/packages/graphql/test/helpers.dart
+++ b/packages/graphql/test/helpers.dart
@@ -1,0 +1,43 @@
+// This
+import 'dart:mirrors';
+import 'dart:convert';
+import 'dart:io' show File, Platform, Directory;
+import 'dart:typed_data' show Uint8List;
+
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:path/path.dart' show dirname, join;
+import 'package:http/http.dart' as http;
+
+import 'package:graphql/client.dart';
+
+NormalizedInMemoryCache getTestCache() => NormalizedInMemoryCache(
+      dataIdFromObject: typenameDataIdFromObject,
+      storageProvider: () => Directory.systemTemp.createTempSync('file_test_'),
+    );
+
+http.StreamedResponse simpleResponse({@required String body, int status}) {
+  final List<int> bytes = utf8.encode(body);
+  final Stream<List<int>> stream =
+      Stream<List<int>>.fromIterable(<List<int>>[bytes]);
+
+  final http.StreamedResponse r = http.StreamedResponse(stream, status ?? 200);
+
+  return r;
+}
+
+class _TestUtils {
+  static String _path;
+
+  static String get path {
+    if (_path == null) {
+      final String basePath =
+          dirname((reflectClass(_TestUtils).owner as LibraryMirror).uri.path);
+      _path = basePath.endsWith('test') ? basePath : join(basePath, 'test');
+    }
+    return _path;
+  }
+}
+
+File tempFile(String fileName) => File(join(_TestUtils.path, fileName));

--- a/packages/graphql/test/multipart_upload_test.dart
+++ b/packages/graphql/test/multipart_upload_test.dart
@@ -1,0 +1,197 @@
+import 'dart:convert';
+import 'dart:io' show File, Directory;
+import 'dart:typed_data' show Uint8List;
+
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:graphql/client.dart';
+
+import './helpers.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+NormalizedInMemoryCache getTestCache() => NormalizedInMemoryCache(
+      dataIdFromObject: typenameDataIdFromObject,
+      storageProvider: () => Directory.systemTemp.createTempSync('file_test_'),
+    );
+
+void main() {
+  HttpLink httpLink;
+  AuthLink authLink;
+  Link link;
+  GraphQLClient graphQLClientClient;
+  MockHttpClient mockHttpClient;
+
+  group('upload', () {
+    const String uploadMutation = r'''
+    mutation($files: [Upload!]!) {
+      multipleUpload(files: $files) {
+        id
+        filename
+        mimetype
+        path
+      }
+    }
+    ''';
+
+    setUp(() {
+      mockHttpClient = MockHttpClient();
+
+      httpLink = HttpLink(
+          uri: 'http://localhost:3001/graphql', httpClient: mockHttpClient);
+
+      authLink = AuthLink(
+        getToken: () async => 'Bearer my-special-bearer-token',
+      );
+
+      link = authLink.concat(httpLink as Link);
+
+      graphQLClientClient = GraphQLClient(
+        cache: getTestCache(),
+        link: link,
+      );
+    });
+
+    test('upload success', () async {
+      Future<void> expectUploadBody(http.ByteStream bodyBytesStream,
+          String boundary, List<File> files) async {
+        final List<Function> expectContinuationList = (() {
+          int i = 0;
+          return <Function>[
+            // ExpectString
+            (Uint8List actual, String expected) => expect(
+                String.fromCharCodes(actual.sublist(i, i += expected.length)),
+                expected),
+            // ExpectBytes
+            (Uint8List actual, Uint8List expected) =>
+                expect(actual.sublist(i, i += expected.length), expected),
+            // Expect final length
+            (int expectedLength) => expect(i, expectedLength),
+          ];
+        })();
+        final Function expectContinuationString = expectContinuationList[0];
+        final Function expectContinuationBytes = expectContinuationList[1];
+        final Function expectContinuationLength = expectContinuationList[2];
+        final Uint8List bodyBytes = await bodyBytesStream.toBytes();
+        expectContinuationString(bodyBytes, '--');
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes,
+            '\r\ncontent-disposition: form-data; name="operations"\r\n\r\n');
+        // operationName of unamed operations is "UNNAMED/" +  document.hashCode.toString()
+        expectContinuationString(bodyBytes,
+            r'{"operationName":null,"variables":{"files":[null,null]},"query":"    mutation($files: [Upload!]!) {\n      multipleUpload(files: $files) {\n        id\n        filename\n        mimetype\n        path\n      }\n    }\n    "}');
+        expectContinuationString(bodyBytes, '\r\n--');
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes,
+            '\r\ncontent-disposition: form-data; name="map"\r\n\r\n{"0":["variables.files.0"],"1":["variables.files.1"]}');
+        expectContinuationString(bodyBytes, '\r\n--');
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes,
+            '\r\ncontent-type: image/jpeg\r\ncontent-disposition: form-data; name="0"; filename="sample_upload.jpg"\r\n\r\n');
+        expectContinuationBytes(bodyBytes, await files[0].readAsBytes());
+        expectContinuationString(bodyBytes, '\r\n--');
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes,
+            '\r\ncontent-type: video/quicktime\r\ncontent-disposition: form-data; name="1"; filename="sample_upload.mov"\r\n\r\n');
+        expectContinuationBytes(bodyBytes, await files[1].readAsBytes());
+        expectContinuationString(bodyBytes, '\r\n--');
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes, '--\r\n');
+        expectContinuationLength(bodyBytes.lengthInBytes);
+      }
+
+      http.ByteStream bodyBytes;
+      when(mockHttpClient.send(any)).thenAnswer((Invocation a) async {
+        bodyBytes = (a.positionalArguments[0] as http.BaseRequest).finalize();
+        return simpleResponse(body: r'''
+{
+  "data": {
+    "multipleUpload": [
+      {
+        "id": "r1odc4PAz",
+        "filename": "sample_upload.jpg",
+        "mimetype": "image/jpeg",
+        "path": "./uploads/r1odc4PAz-sample_upload.jpg"
+      },
+      {
+        "id": "5Ea18qlMur",
+        "filename": "sample_upload.mov",
+        "mimetype": "video/quicktime",
+        "path": "./uploads/5Ea18qlMur-sample_upload.mov"
+      }
+    ]
+  }
+}
+        ''');
+      });
+
+      final List<File> files = <String>[
+        'sample_upload.jpg',
+        'sample_upload.mov'
+      ].map((String fileName) => tempFile(fileName)).toList();
+
+      final MutationOptions _options = MutationOptions(
+        document: uploadMutation,
+        variables: <String, dynamic>{
+          'files': files,
+        },
+      );
+      final QueryResult r = await graphQLClientClient.mutate(_options);
+
+      expect(r.errors, isNull);
+      expect(r.data, isNotNull);
+
+      final http.MultipartRequest request =
+          verify(mockHttpClient.send(captureAny)).captured.first
+              as http.MultipartRequest;
+      expect(request.method, 'post');
+      expect(request.url.toString(), 'http://localhost:3001/graphql');
+      expect(request.headers['accept'], '*/*');
+      expect(
+          request.headers['Authorization'], 'Bearer my-special-bearer-token');
+      final List<String> contentTypeStringSplit =
+          request.headers['content-type'].split('; boundary=');
+      expect(contentTypeStringSplit[0], 'multipart/form-data');
+      await expectUploadBody(bodyBytes, contentTypeStringSplit[1], files);
+
+      final List<Map<String, dynamic>> multipleUpload =
+          (r.data['multipleUpload'] as List<dynamic>)
+              .cast<Map<String, dynamic>>();
+
+      expect(multipleUpload, <Map<String, String>>[
+        <String, String>{
+          'id': 'r1odc4PAz',
+          'filename': 'sample_upload.jpg',
+          'mimetype': 'image/jpeg',
+          'path': './uploads/r1odc4PAz-sample_upload.jpg'
+        },
+        <String, String>{
+          'id': '5Ea18qlMur',
+          'filename': 'sample_upload.mov',
+          'mimetype': 'video/quicktime',
+          'path': './uploads/5Ea18qlMur-sample_upload.mov'
+        },
+      ]);
+    });
+
+    //test('upload fail error response', () {
+    //  const String responseBody = json.encode({
+    //    "errors":[
+    //      {
+    //        "message": r'Variable "$files" of required type "[Upload!]!" was not provided.',
+    //        "locations": [{ "line" :1, "column" :14 }],
+    //        "extensions": {
+    //          "code": "INTERNAL_SERVER_ERROR",
+    //          "exception": {
+    //             "stacktrace": [ r'GraphQLError: Variable "$files" of required type "[Upload!]!" was not provided.', ... ]
+    //          }
+    //        }
+    //      }
+    //    ]
+    //  });
+    //  const int statusCode = 400;
+    //});
+  });
+}

--- a/packages/graphql_flutter/pubspec.lock
+++ b/packages/graphql_flutter/pubspec.lock
@@ -91,9 +91,9 @@ packages:
   graphql:
     dependency: "direct main"
     description:
-      name: graphql
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../graphql"
+      relative: true
+    source: path
     version: "1.0.1-beta.7"
   graphql_parser:
     dependency: transitive

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -9,7 +9,8 @@ authors:
   - Michael Joseph Rosenthal <rosenthalm93@gmail.com>
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
 dependencies:
-  graphql: ^1.0.1-beta.7
+  graphql:
+    path: ../graphql #^1.0.1-beta.7
   flutter:
     sdk: flutter
   meta: ^1.1.6


### PR DESCRIPTION
closes #235, #264

### Breaking changes

- made `operationName` nullable because anonymous operations are allowed 

#### Fixes / Enhancements

- Fixed anonymous `{ foo  { bar } }` queries (were broken)
- Added an `_identifier` to `RawOperationData` (maybe a bit redundant with the document in the `toKey` as well
- Cleaned up unit tests some