### PR TITLE
Loosen websocket init constraints

### DIFF
--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,1 +1,8 @@
 See [GitHub Releases](https://github.com/zino-app/graphql-flutter/releases).
+
+* Loosened `initPayload` to `dynamic` to support many use-cases,
+  Removed `InitOperation`'s excessive and inconsistent json encoding.
+  Old implmentation can still be utilized as `legacyInitPayload`
+  until deprecation
+
+* Fixed broken anonymous operations

--- a/packages/graphql/lib/src/core/raw_operation_data.dart
+++ b/packages/graphql/lib/src/core/raw_operation_data.dart
@@ -24,7 +24,6 @@ class RawOperationData {
   Map<String, dynamic> variables;
 
   String _operationName;
-  String _documentIdentifier;
 
   /// The last operation name appearing in the contained document.
   String get operationName {
@@ -34,6 +33,10 @@ class RawOperationData {
     return _operationName;
   }
 
+  String _documentIdentifier;
+
+  /// The client identifier for this operation,
+  // TODO remove $document from key? A bit redundant, though that's not the worst thing
   String get _identifier {
     _documentIdentifier ??=
         operationName ?? 'UNNAMED/' + document.hashCode.toString();

--- a/packages/graphql/lib/src/websocket/messages.dart
+++ b/packages/graphql/lib/src/websocket/messages.dart
@@ -52,7 +52,26 @@ abstract class GraphQLSocketMessage extends JsonSerializable {
 class InitOperation extends GraphQLSocketMessage {
   InitOperation(this.payload) : super(MessageTypes.GQL_CONNECTION_INIT);
 
-  final Map<String, String> payload;
+  final dynamic payload;
+
+  @override
+  dynamic toJson() {
+    final Map<String, dynamic> jsonMap = <String, dynamic>{};
+    jsonMap['type'] = type;
+
+    if (payload != null) {
+      jsonMap['payload'] = payload;
+    }
+
+    return jsonMap;
+  }
+}
+
+@deprecated
+
+/// The old implementation of [InitOperation]
+class LegacyInitOperation extends InitOperation {
+  LegacyInitOperation(dynamic payload) : super(payload);
 
   @override
   dynamic toJson() {


### PR DESCRIPTION
closes #208
closes #242
supersedes #137
 
### Breaking changes

- Made `initPayload` to `SocketClientConfig` `dynamic` because many use cases require it.
- Removed `json.encoding` from `InitOperation.toJson` because 👆 and because encoding is handled in `_write` anyways

#### Fixes / Enhancements

- Added a `legacyInitPayload` that will use the old logic,
  with a warning to comment on this PR if anyone really does need it

