### PR TITLE
docs: add variable type to query example

### DIFF
--- a/packages/graphql_flutter/README.md
+++ b/packages/graphql_flutter/README.md
@@ -171,7 +171,7 @@ Creating a query is as simple as creating a multiline string:
 
 ```dart
 String readRepositories = """
-  query ReadRepositories(\$nRepositories) {
+  query ReadRepositories(\$nRepositories: Int!) {
     viewer {
       repositories(last: \$nRepositories) {
         nodes {


### PR DESCRIPTION
#### Docs

- Added missing variable type in query example
