### PR TITLE
Handle cyclic  data structure writes

### DIFF
--- a/packages/graphql/lib/src/cache/normalized_in_memory.dart
+++ b/packages/graphql/lib/src/cache/normalized_in_memory.dart
@@ -65,7 +65,7 @@ class NormalizedInMemoryCache extends InMemoryCache {
   /// *WARNING* if your system allows cyclical references, this will break
   dynamic denormalizedRead(String key) {
     try {
-      return Traversal(_denormalizingDereference).traverse(super.read(key));
+      return Traversal(_denormalizingDereference).traverse(read(key));
     } catch (error) {
       if (error is StackOverflowError) {
         throw NormalizationException(

--- a/packages/graphql/lib/src/cache/normalized_in_memory.dart
+++ b/packages/graphql/lib/src/cache/normalized_in_memory.dart
@@ -93,7 +93,7 @@ class NormalizedInMemoryCache extends InMemoryCache {
   // get a normalizer for a given target map
   Normalizer _normalizerFor(Map<String, Object> into) {
     List<String> normalizer(Object node) {
-      final String dataId = dataIdFromObject(node);
+      final dataId = dataIdFromObject(node);
       if (dataId != null) {
         return <String>[prefix, dataId];
       }
@@ -122,7 +122,7 @@ class NormalizedInMemoryCache extends InMemoryCache {
   ]) {
     normalizer ??= _normalizerFor(into);
     if (value is Map<String, Object>) {
-      final Map<String, Object> merged = _mergedWithExisting(into, key, value);
+      final merged = _mergedWithExisting(into, key, value);
       final Traversal traversal = Traversal(
         normalizer,
         transformSideEffect: _traversingWriteInto(into),
@@ -162,7 +162,7 @@ SideEffect _traversingWriteInto(Map<String, Object> into) {
   void sideEffect(Object ref, Object value, Traversal traversal) {
     final String key = (ref as List<String>)[1];
     if (value is Map<String, Object>) {
-      final Map<String, Object> merged = _mergedWithExisting(into, key, value);
+      final merged = _mergedWithExisting(into, key, value);
       into[key] = traversal.traverseValues(merged);
     } else {
       // writing non-map data to the store is allowed,
@@ -178,8 +178,8 @@ SideEffect _traversingWriteInto(Map<String, Object> into) {
 /// get the given value merged with any pre-existing map with the same key
 Map<String, Object> _mergedWithExisting(
     Map<String, Object> into, String key, Map<String, Object> value) {
-  final Object existing = into[key];
+  final existing = into[key];
   return (existing is Map<String, Object>)
-      ? deeplyMergeLeft(<Map<String, Object>>[existing, value])
+      ? deeplyMergeLeft([existing, value])
       : value;
 }

--- a/packages/graphql/lib/src/cache/optimistic.dart
+++ b/packages/graphql/lib/src/cache/optimistic.dart
@@ -82,7 +82,7 @@ class OptimisticCache extends NormalizedInMemoryCache {
       if (patch.data.containsKey(key)) {
         final Object patchData = patch.data[key];
         if (value is Map<String, Object> && patchData is Map<String, Object>) {
-          value = deeplyMergeLeft(<Map<String, Object>>[
+          value = deeplyMergeLeft([
             value as Map<String, Object>,
             patchData,
           ]);

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -17,7 +17,6 @@ enum QueryLifecycle {
   SIDE_EFFECTS_PENDING,
   SIDE_EFFECTS_BLOCKING,
 
-  // right now only Mutations ever become completed
   COMPLETED,
   CLOSED
 }

--- a/packages/graphql/lib/src/utilities/helpers.dart
+++ b/packages/graphql/lib/src/utilities/helpers.dart
@@ -71,6 +71,5 @@ Map<String, dynamic> deeplyMergeLeft(
   Iterable<Map<String, dynamic>> maps,
 ) {
   // prepend an empty literal for functional immutability
-  return (<Map<String, dynamic>>[<String, dynamic>{}]..addAll(maps))
-      .reduce(_recursivelyAddAll);
+  return (<Map<String, dynamic>>[{}]..addAll(maps)).reduce(_recursivelyAddAll);
 }

--- a/packages/graphql/lib/src/utilities/traverse.dart
+++ b/packages/graphql/lib/src/utilities/traverse.dart
@@ -1,32 +1,62 @@
+import 'dart:collection';
+
 typedef Transform = Object Function(Object node);
+typedef SideEffect = void Function(
+  Object transformResult,
+  Object node,
+  Traversal traversal,
+);
 
-Map<String, Object> traverseValues(
-  Map<String, Object> node,
-  Transform transform,
-) {
-  return node.map<String, Object>(
-    (String key, Object value) => MapEntry<String, Object>(
-          key,
-          traverse(value, transform),
-        ),
-  );
-}
-
-// Attempts to apply the transform to every leaf of the data structure recursively.
-// Stops recursing when a node is transformed (returns non-null)
-Object traverse(Object node, Transform transform) {
-  final Object transformed = transform(node);
-  if (transformed != null) {
-    return transformed;
+class Traversal {
+  Traversal(
+    this.transform, {
+    this.transformSideEffect,
+    this.seenObjects,
+  }) {
+    seenObjects ??= HashSet<int>();
   }
 
-  if (node is List<Object>) {
-    return node
-        .map<Object>((Object node) => traverse(node, transform))
-        .toList();
+  Transform transform;
+
+  /// An optional side effect to call when a node is transformed.
+  SideEffect transformSideEffect;
+  HashSet<int> seenObjects;
+
+  bool hasAlreadySeen(Object node) {
+    final bool wasAdded = seenObjects.add(node.hashCode);
+    return !wasAdded;
   }
-  if (node is Map<String, Object>) {
-    return traverseValues(node, transform);
+
+  /// Traverse only the values of the given map
+  Map<String, Object> traverseValues(Map<String, Object> node) {
+    return node.map<String, Object>(
+      (String key, Object value) => MapEntry<String, Object>(
+            key,
+            traverse(value),
+          ),
+    );
   }
-  return node;
+
+  // Attempts to apply the transform to every leaf of the data structure recursively.
+  // Stops recursing when a node is transformed (returns non-null)
+  Object traverse(Object node) {
+    final Object transformed = transform(node);
+    if (hasAlreadySeen(node)) {
+      return transformed ?? node;
+    }
+    if (transformed != null) {
+      if (transformSideEffect != null) {
+        transformSideEffect(transformed, node, this);
+      }
+      return transformed;
+    }
+
+    if (node is List<Object>) {
+      return node.map<Object>((Object node) => traverse(node)).toList();
+    }
+    if (node is Map<String, Object>) {
+      return traverseValues(node);
+    }
+    return node;
+  }
 }

--- a/packages/graphql/test/normalized_in_memory_test.dart
+++ b/packages/graphql/test/normalized_in_memory_test.dart
@@ -173,13 +173,13 @@ Map<String, Object> get cyclicalObjOperationData {
   return {'a': a};
 }
 
-final Map<String, Object> cyclicalObjNormalizedA = <String, Object>{
+final Map<String, Object> cyclicalObjNormalizedA = {
   '__typename': 'A',
   'id': 1,
   'b': <String>['@cache/reference', 'B/5'],
 };
 
-final Map<String, Object> cyclicalObjNormalizedB = <String, Object>{
+final Map<String, Object> cyclicalObjNormalizedB = {
   '__typename': 'B',
   'id': 5,
   'as': [

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -23,6 +23,6 @@ dev_dependencies:
   test: ^1.5.3
 environment:
   sdk: '>=2.2.0 <3.0.0'
-dependency_overrides:
-  graphql:
-    path: ../graphql
+# dependency_overrides:
+#  graphql:
+#    path: ../graphql


### PR DESCRIPTION
Closes #246 
Closes #299

#### Fixes / Enhancements

- Added cyclic structure normalization by making `traverse` a stateful `Traversal` and tracking object hashCodes
- added tests for `OptimisticCache`
- made `denormalizedRead` call `read` instead of `super.read` so it behaves optimistically in `OptimisticCache`
