### PR TITLE
Chore/skip browser test

### DIFF
--- a/packages/graphql/test/in_memory_storage_test.dart
+++ b/packages/graphql/test/in_memory_storage_test.dart
@@ -53,6 +53,8 @@ void main() {
       cache.reset();
       await cache.restore();
       expect(cache.read(aKey), equals(aData));
+    }, onPlatform: {
+      "browser": Skip("Browser does not support dart:io (see #295)")
     });
 
     test('saving concurrently wont error', () async {
@@ -81,6 +83,8 @@ void main() {
       expect(cache.read(cKey), equals(cData));
       expect(cache.read(dKey), equals(dData));
       expect(cache.read(eKey), equals(eData));
+    }, onPlatform: {
+      "browser": Skip("Browser does not support dart:io (see #295)")
     });
   });
 }

--- a/packages/graphql/test/multipart_upload_test.dart
+++ b/packages/graphql/test/multipart_upload_test.dart
@@ -173,6 +173,8 @@ void main() {
           'path': './uploads/5Ea18qlMur-sample_upload.mov'
         },
       ]);
+    }, onPlatform: {
+      "browser": Skip("Browser does not support dart:mirrors"),
     });
 
     //test('upload fail error response', () {


### PR DESCRIPTION
skip 3 tests on browser platform, relating to the effort to make this package compatible to web/browser #295.

You can test this PR by running `pub run test test -p chrome` and `pub run test test -p vm`.

`pub run test test -p chrome` is not yet supported on CI, see https://github.com/cirruslabs/docker-images-flutter/issues/17