### PR TITLE
Chore/file system exception

### DIFF
--- a/packages/graphql/example/bin/main.dart
+++ b/packages/graphql/example/bin/main.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'dart:io' show stdout, stderr, exit;
 
 import 'package:args/args.dart';
 import 'package:graphql/client.dart';

--- a/packages/graphql/lib/src/cache/in_memory.dart
+++ b/packages/graphql/lib/src/cache/in_memory.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' show Directory, File, IOSink, FileSystemException;
 
 import 'package:meta/meta.dart';
 // TODO need to think about this

--- a/packages/graphql/lib/src/cache/in_memory.dart
+++ b/packages/graphql/lib/src/cache/in_memory.dart
@@ -120,7 +120,7 @@ class InMemoryCache implements Cache {
       final File file = await _localStorageFile;
       final HashMap<String, dynamic> storedHashMap = HashMap<String, dynamic>();
 
-      if (file.existsSync()) {
+      if (await file.exists()) {
         final Stream<List<int>> inputStream = file.openRead();
 
         await for (String line in inputStream

--- a/packages/graphql/lib/src/utilities/helpers.dart
+++ b/packages/graphql/lib/src/utilities/helpers.dart
@@ -36,14 +36,14 @@ Map<String, dynamic> _recursivelyAddAll(
   Map<String, dynamic> target,
   Map<String, dynamic> source,
 ) {
-  target = unwrapMap(target);
+  target = Map.from(unwrapMap(target));
   source = unwrapMap(source);
   source.forEach((String key, dynamic value) {
     if (target.containsKey(key) &&
         target[key] is Map &&
         value != null &&
         value is Map<String, dynamic>) {
-      _recursivelyAddAll(
+      target[key] = _recursivelyAddAll(
         target[key] as Map<String, dynamic>,
         value,
       );

--- a/packages/graphql/test/helpers.dart
+++ b/packages/graphql/test/helpers.dart
@@ -11,7 +11,7 @@ import 'package:graphql/client.dart';
 
 NormalizedInMemoryCache getTestCache() => NormalizedInMemoryCache(
       dataIdFromObject: typenameDataIdFromObject,
-      storageProvider: () => Directory.systemTemp.createTempSync('file_test_'),
+      storageProvider: () => Directory.systemTemp.createTemp('file_test_'),
     );
 
 http.StreamedResponse simpleResponse({@required String body, int status}) {

--- a/packages/graphql/test/in_memory_storage_test.dart
+++ b/packages/graphql/test/in_memory_storage_test.dart
@@ -53,6 +53,8 @@ void main() {
       cache.reset();
       await cache.restore();
       expect(cache.read(aKey), equals(aData));
+    }, onPlatform: {
+      "browser": Skip("Browser does not support dart:io (see #295)")
     });
 
     test('saving concurrently wont error', () async {
@@ -81,6 +83,8 @@ void main() {
       expect(cache.read(cKey), equals(cData));
       expect(cache.read(dKey), equals(dData));
       expect(cache.read(eKey), equals(eData));
+    }, onPlatform: {
+      "browser": Skip("Browser does not support dart:io (see #295)")
     });
   });
 }

--- a/packages/graphql/test/in_memory_storage_test.dart
+++ b/packages/graphql/test/in_memory_storage_test.dart
@@ -57,6 +57,61 @@ void main() {
       "browser": Skip("Browser does not support dart:io (see #295)")
     });
 
+    test('.write avoids overriding a superset with a subset of a field (#155)',
+        () async {
+      final InMemoryCache cache = InMemoryCache(
+        storageProvider: () => customStorageDirectory,
+      );
+      cache.write(aKey, aData);
+
+      final Map<String, Object> anotherAData = <String, Object>{
+        'a': <String, Object>{
+          'key': 'val',
+        },
+      };
+      cache.write(aKey, anotherAData);
+
+      await cache.save();
+      cache.reset();
+      await cache.restore();
+      expect(
+        cache.read(aKey),
+        equals(<String, Object>{
+          'a': {'__typename': 'A', 'key': 'val'}
+        }),
+      );
+    }, onPlatform: {
+      "browser": Skip("Browser does not support dart:io (see #295)")
+    });
+
+    test('.write does not mutate input', () async {
+      final InMemoryCache cache = InMemoryCache(
+        storageProvider: () => customStorageDirectory,
+      );
+      cache.write(aKey, aData);
+      final Map<String, Object> anotherAData = <String, Object>{
+        'a': <String, Object>{
+          'key': 'val',
+        },
+      };
+      cache.write(aKey, anotherAData);
+
+      expect(
+        aData,
+        equals(<String, Object>{
+          'a': {'__typename': 'A'}
+        }),
+      );
+      expect(
+        anotherAData,
+        equals(<String, Object>{
+          'a': {'key': 'val'}
+        }),
+      );
+    }, onPlatform: {
+      "browser": Skip("Browser does not support dart:io (see #295)")
+    });
+
     test('saving concurrently wont error', () async {
       final InMemoryCache cache = InMemoryCache(
         storageProvider: () => customStorageDirectory,

--- a/packages/graphql/test/multipart_upload_test.dart
+++ b/packages/graphql/test/multipart_upload_test.dart
@@ -13,7 +13,7 @@ class MockHttpClient extends Mock implements http.Client {}
 
 NormalizedInMemoryCache getTestCache() => NormalizedInMemoryCache(
       dataIdFromObject: typenameDataIdFromObject,
-      storageProvider: () => Directory.systemTemp.createTempSync('file_test_'),
+      storageProvider: () => Directory.systemTemp.createTemp('file_test_'),
     );
 
 void main() {

--- a/packages/graphql/test/multipart_upload_test.dart
+++ b/packages/graphql/test/multipart_upload_test.dart
@@ -173,6 +173,8 @@ void main() {
           'path': './uploads/5Ea18qlMur-sample_upload.mov'
         },
       ]);
+    }, onPlatform: {
+      "browser": Skip("Browser does not support dart:mirrors"),
     });
 
     //test('upload fail error response', () {

--- a/packages/graphql/test/normalized_in_memory_test.dart
+++ b/packages/graphql/test/normalized_in_memory_test.dart
@@ -189,7 +189,7 @@ final Map<String, Object> cyclicalObjNormalizedB = {
 
 NormalizedInMemoryCache getTestCache() => NormalizedInMemoryCache(
       dataIdFromObject: typenameDataIdFromObject,
-      storageProvider: () => Directory.systemTemp.createTempSync('file_test_'),
+      storageProvider: () => Directory.systemTemp.createTemp('file_test_'),
     );
 
 void main() {

--- a/packages/graphql/test/optimistic_cache_test.dart
+++ b/packages/graphql/test/optimistic_cache_test.dart
@@ -160,7 +160,7 @@ final Map<String, Object> cyclicalNormalizedB = <String, Object>{
 
 OptimisticCache getTestCache() => OptimisticCache(
       dataIdFromObject: typenameDataIdFromObject,
-      storageProvider: () => Directory.systemTemp.createTempSync('file_test_'),
+      storageProvider: () => Directory.systemTemp.createTemp('file_test_'),
     );
 
 void main() {


### PR DESCRIPTION
Should be merged only after #312.

increase test coverage on `dart:io` related, relating to the effort to make this package compatible to web/browser #295. This commit is about `FileSystemException`.

While doing this, I happen to discover that in `in_memory` code and some places in our test are using `sync` variation of file/dir operations, all of which have been changes to async.