### PR TITLE
test(client): remove `mirror`

### DIFF
--- a/packages/graphql/test/helpers.dart
+++ b/packages/graphql/test/helpers.dart
@@ -1,5 +1,3 @@
-// This
-import 'dart:mirrors';
 import 'dart:convert';
 import 'dart:io' show File, Directory;
 
@@ -23,18 +21,4 @@ http.StreamedResponse simpleResponse({@required String body, int status}) {
 
   return r;
 }
-
-class _TestUtils {
-  static String _path;
-
-  static String get path {
-    if (_path == null) {
-      final String basePath =
-          dirname((reflectClass(_TestUtils).owner as LibraryMirror).uri.path);
-      _path = basePath.endsWith('test') ? basePath : join(basePath, 'test');
-    }
-    return _path;
-  }
-}
-
-File tempFile(String fileName) => File(join(_TestUtils.path, fileName));
+File tempFile(String fileName) => File(join(Directory.current.path, fileName));


### PR DESCRIPTION
dart test, either in flutter or web browser, does not support mirror,
see https://github.com/dart-lang/sdk/issues/30538 and
https://github.com/flutter/flutter/issues/1150.
Using `Directory.current.path` might still be problematic for web browser later on,
but now let's focus on flutter only.
