### PR TITLE
Cleanup some dartfmt / publish --dry-run complaints

### DIFF
--- a/packages/graphql/lib/src/core/raw_operation_data.dart
+++ b/packages/graphql/lib/src/core/raw_operation_data.dart
@@ -5,7 +5,7 @@ import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 
 import 'package:graphql/src/utilities/get_from_ast.dart' show getOperationName;
-import 'package:graphql/src/link/http//link_http_helper_deprecated_stub.dart'
+import 'package:graphql/src/link/http/link_http_helper_deprecated_stub.dart'
     if (dart.library.io) 'package:graphql/src/link/http/link_http_helper_deprecated_io.dart';
 
 class RawOperationData {

--- a/packages/graphql/lib/src/utilities/file.dart
+++ b/packages/graphql/lib/src/utilities/file.dart
@@ -1,9 +1,3 @@
-import 'dart:async';
-import 'package:http/http.dart';
-
-import './file_stub.dart' as impl
+export './file_stub.dart'
     if (dart.library.html) './file_html.dart'
     if (dart.library.io) './file_io.dart';
-
-/// Input's type must be either `io.File` or `html.File`
-FutureOr<MultipartFile> multipartFileFrom(/*io.File or html.File*/ f) => impl.multipartFileFrom(f);

--- a/packages/graphql/lib/utilities.dart
+++ b/packages/graphql/lib/utilities.dart
@@ -1,3 +1,1 @@
-library graphql;
-
 export 'package:graphql/src/utilities/file.dart' show multipartFileFrom;

--- a/packages/graphql_flutter/lib/src/caches.dart
+++ b/packages/graphql_flutter/lib/src/caches.dart
@@ -6,8 +6,8 @@ import 'package:path_provider/path_provider.dart'
 
 import 'package:graphql/client.dart' as client;
 
-final FutureOr<String> flutterStoragePrefix = (() async =>
-    (await getApplicationDocumentsDirectory()).path)();
+final FutureOr<String> flutterStoragePrefix =
+    (() async => (await getApplicationDocumentsDirectory()).path)();
 
 class InMemoryCache extends client.InMemoryCache {
   InMemoryCache() : super(storagePrefix: flutterStoragePrefix);


### PR DESCRIPTION
Resolve some of the complaints from pub:
https://pub.dev/packages/graphql/versions/1.1.1-beta.5#-analysis-tab-

Also moved `graphql/utility.dart` to `graphql/utlities.dart` for consistency
