### PR TITLE
Add FetchMore Feature

### DIFF
--- a/examples/starwars/lib/client_provider.dart
+++ b/examples/starwars/lib/client_provider.dart
@@ -20,7 +20,7 @@ ValueNotifier<GraphQLClient> clientFor({
   @required String uri,
   String subscriptionUri,
 }) {
-  Link link = HttpLink(uri: uri) as Link;
+  Link link = HttpLink(uri: uri);
   if (subscriptionUri != null) {
     final WebSocketLink websocketLink = WebSocketLink(
       url: subscriptionUri,

--- a/examples/starwars/lib/episode/hero_query.dart
+++ b/examples/starwars/lib/episode/hero_query.dart
@@ -31,7 +31,11 @@ class HeroForEpisode extends StatelessWidget {
           'ep': episodeToJson(episode),
         },
       ),
-      builder: (QueryResult result, {BoolCallback refetch}) {
+      builder: (
+        QueryResult result, {
+        BoolCallback refetch,
+        FetchMore fetchMore,
+      }) {
         if (result.errors != null) {
           return Text(result.errors.toString());
         }

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -139,14 +139,11 @@ class ObservableQuery {
 
     if (fetchMoreOptions.document != null) {
       // use query as is
-      combinedOptions = fetchMoreOptions;
+      combinedOptions = fetchMoreOptions as QueryOptions;
     } else {
       /// combine the QueryOptions and FetchMoreOptions
       combinedOptions = QueryOptions(
         document: options.document,
-        errorPolicy: fetchMoreOptions.errorPolicy ?? options.errorPolicy,
-        fetchPolicy: FetchPolicy.networkOnly,
-        context: options.context,
         variables: {...options.variables, ...fetchMoreOptions.variables},
       );
     }

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -163,6 +163,8 @@ class ObservableQuery {
     var combineData =
         fetchMoreOptions.updateQuery(latestResult.data, results.data);
 
+    assert(combineData != null);
+
     results.data = combineData;
 
     // stream the new results and rebuild

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -160,16 +160,6 @@ class ObservableQuery {
         fetchMoreResult.data,
       );
       assert(fetchMoreResult.data != null, 'updateQuery result cannot be null');
-
-      // we don't want to update variables if merging results failed
-      if (fetchMoreOptions.updateVariables != null) {
-        options.variables = fetchMoreOptions.updateVariables(
-          options.variables,
-          combinedOptions.variables,
-        );
-        assert(options.variables != null,
-            'updateVariables must return a Map<String, dynamic>');
-      }
     } catch (error) {
       if (fetchMoreResult.hasErrors) {
         // because the updateQuery failure might have been because of these errors,

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -171,8 +171,8 @@ class WatchQueryOptions extends QueryOptions {
 
 /// method to merge fetch more results with current results
 typedef dynamic UpdateQuery(
-  dynamic prev,
-  dynamic results,
+  dynamic previousResults,
+  dynamic nextResults,
 );
 
 /// options for fetchmore operations

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -1,3 +1,4 @@
+import 'package:graphql/src/core/query_result.dart';
 import 'package:meta/meta.dart';
 
 import 'package:graphql/src/utilities/helpers.dart';
@@ -169,24 +170,41 @@ class WatchQueryOptions extends QueryOptions {
   }
 }
 
-/// method to merge fetch more results with current results
+/// merge fetchMore result data with earlier result data
 typedef dynamic UpdateQuery(
-  dynamic previousQueryResults,
-  dynamic fetchmoreQueryResults,
+  dynamic previousResult,
+  dynamic fetchMoreResult,
+);
+
+/// merge fetch more variables with old variables
+/// AFTER the query has been run
+typedef Map<String, dynamic> UpdateVariables(
+  Map<String, dynamic> previousVariables,
+  Map<String, dynamic> fetchMoreVariables,
 );
 
 /// options for fetchmore operations
 class FetchMoreOptions {
   FetchMoreOptions({
-    String document,
-    Map<String, dynamic> variables,
-    @required UpdateQuery updateQuery,
-  })  : assert(updateQuery != null),
-        this.updateQuery = updateQuery,
-        this.variables = variables,
-        this.document = document;
+    this.document,
+    this.variables = const <String, dynamic>{},
+    @required this.updateQuery,
+    this.updateVariables,
+  }) : assert(updateQuery != null);
 
   final String document;
   final Map<String, dynamic> variables;
+
+  /// Strategy for merging the fetchMore result
+  /// with the results already in the cache
   UpdateQuery updateQuery;
+
+  /// Optional: Strategy for merging the fetchMore variables
+  /// with the earlier variables AFTER the query is run.
+  ///
+  /// For a conceptual example, the data from
+  /// `fetchItems({first: 1, last: 5}) + fetchItems.fetchMore({ first: 6, last: 10 })`
+  /// would coorespond to  `fetchItems({first: 1, last: 10})`,
+  /// so we might want to update our variables accordingly
+  UpdateVariables updateVariables;
 }

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -1,4 +1,3 @@
-import 'package:graphql/src/core/query_result.dart';
 import 'package:meta/meta.dart';
 
 import 'package:graphql/src/utilities/helpers.dart';
@@ -172,8 +171,8 @@ class WatchQueryOptions extends QueryOptions {
 
 /// merge fetchMore result data with earlier result data
 typedef dynamic UpdateQuery(
-  dynamic previousResult,
-  dynamic fetchMoreResult,
+  dynamic previousResultData,
+  dynamic fetchMoreResultData,
 );
 
 /// options for fetchmore operations
@@ -187,7 +186,7 @@ class FetchMoreOptions {
   final String document;
   final Map<String, dynamic> variables;
 
-  /// Strategy for merging the fetchMore result
-  /// with the results already in the cache
+  /// Strategy for merging the fetchMore result data
+  /// with the result data already in the cache
   UpdateQuery updateQuery;
 }

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -176,20 +176,12 @@ typedef dynamic UpdateQuery(
   dynamic fetchMoreResult,
 );
 
-/// merge fetch more variables with old variables
-/// AFTER the query has been run
-typedef Map<String, dynamic> UpdateVariables(
-  Map<String, dynamic> previousVariables,
-  Map<String, dynamic> fetchMoreVariables,
-);
-
 /// options for fetchmore operations
 class FetchMoreOptions {
   FetchMoreOptions({
     this.document,
     this.variables = const <String, dynamic>{},
     @required this.updateQuery,
-    this.updateVariables,
   }) : assert(updateQuery != null);
 
   final String document;
@@ -198,13 +190,4 @@ class FetchMoreOptions {
   /// Strategy for merging the fetchMore result
   /// with the results already in the cache
   UpdateQuery updateQuery;
-
-  /// Optional: Strategy for merging the fetchMore variables
-  /// with the earlier variables AFTER the query is run.
-  ///
-  /// For a conceptual example, the data from
-  /// `fetchItems({first: 1, last: 5}) + fetchItems.fetchMore({ first: 6, last: 10 })`
-  /// would coorespond to  `fetchItems({first: 1, last: 10})`,
-  /// so we might want to update our variables accordingly
-  UpdateVariables updateVariables;
 }

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -171,28 +171,22 @@ class WatchQueryOptions extends QueryOptions {
 
 /// method to merge fetch more results with current results
 typedef dynamic UpdateQuery(
-  dynamic previousResults,
-  dynamic nextResults,
+  dynamic previousQueryResults,
+  dynamic fetchmoreQueryResults,
 );
 
 /// options for fetchmore operations
-class FetchMoreOptions extends QueryOptions {
+class FetchMoreOptions {
   FetchMoreOptions({
-    String document, // optional document
+    String document,
     Map<String, dynamic> variables,
-    FetchPolicy fetchPolicy = FetchPolicy.networkOnly,
-    ErrorPolicy errorPolicy = ErrorPolicy.none,
-    Map<String, dynamic> context,
     @required UpdateQuery updateQuery,
   })  : assert(updateQuery != null),
         this.updateQuery = updateQuery,
-        super(
-          document: document,
-          variables: variables,
-          fetchPolicy: fetchPolicy,
-          errorPolicy: errorPolicy,
-          context: context,
-        );
+        this.variables = variables,
+        this.document = document;
 
+  final String document;
+  final Map<String, dynamic> variables;
   UpdateQuery updateQuery;
 }

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -168,3 +168,31 @@ class WatchQueryOptions extends QueryOptions {
     return areDifferentVariables(a.variables, b.variables);
   }
 }
+
+/// method to merge fetch more results with current results
+typedef dynamic UpdateQuery(
+  dynamic prev,
+  dynamic results,
+);
+
+/// options for fetchmore operations
+class FetchMoreOptions extends QueryOptions {
+  FetchMoreOptions({
+    String document, // optional document
+    Map<String, dynamic> variables,
+    FetchPolicy fetchPolicy = FetchPolicy.networkOnly,
+    ErrorPolicy errorPolicy = ErrorPolicy.none,
+    Map<String, dynamic> context,
+    @required UpdateQuery updateQuery,
+  })  : assert(updateQuery != null),
+        this.updateQuery = updateQuery,
+        super(
+          document: document,
+          variables: variables,
+          fetchPolicy: fetchPolicy,
+          errorPolicy: errorPolicy,
+          context: context,
+        );
+
+  UpdateQuery updateQuery;
+}

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -1,12 +1,13 @@
 name: graphql
-description: A stand-alone GraphQL client for Dart, bringing all the features from
+description:
+  A stand-alone GraphQL client for Dart, bringing all the features from
   a modern GraphQL client to one easy to use package.
 version: 1.1.1-beta.8
 authors:
-- Eus Dima <eus@zinoapp.com>
-- Zino Hofmann <zino@zinoapp.com>
-- Michael Joseph Rosenthal <rosenthalm93@gmail.com>
-- TruongSinh Tran-Nguyen <i@truongsinh.pro>
+  - Eus Dima <eus@zinoapp.com>
+  - Zino Hofmann <zino@zinoapp.com>
+  - Michael Joseph Rosenthal <rosenthalm93@gmail.com>
+  - TruongSinh Tran-Nguyen <i@truongsinh.pro>
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql
 dependencies:
   meta: ^1.1.6
@@ -24,4 +25,4 @@ dev_dependencies:
   test: ^1.5.3
   test_coverage: ^0.2.0
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: ">=2.2.2 <3.0.0"

--- a/packages/graphql_flutter/example/lib/fetchmore/main.dart
+++ b/packages/graphql_flutter/example/lib/fetchmore/main.dart
@@ -89,8 +89,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 variables: <String, dynamic>{
                   'nRepositories': nRepositories,
                   'query': _searchQuery,
-                  'cursor':
-                      null // set cursor to null so as to start at the beginning
+                  // set cursor to null so as to start at the beginning
+                  'cursor': null
                 },
                 //pollInterval: 10,
               ),
@@ -115,24 +115,24 @@ class _MyHomePageState extends State<MyHomePage> {
                     (result.data['search']['nodes'] as List<dynamic>);
 
                 final Map pageInfo = result.data['search']['pageInfo'];
-
+                final String fetchMoreCursor = pageInfo['endCursor'];
                 FetchMoreOptions opts = FetchMoreOptions(
-                  variables: {'cursor': pageInfo['endCursor']},
-                  updateQuery: (prev, res) {
+                  variables: {'cursor': fetchMoreCursor},
+                  updateQuery: (previousResultData, fetchMoreResultData) {
                     // this is where you combine your previous data and response
-                    // in case of this, we want to display previous repos plus next repos
+                    // in this case, we want to display previous repos plus next repos
                     // so, we combine data in both into a single list of repos
                     final List<dynamic> repos = [
-                      ...prev['search']['nodes'] as List<dynamic>,
-                      ...res['search']['nodes'] as List<dynamic>
+                      ...previousResultData['search']['nodes'] as List<dynamic>,
+                      ...fetchMoreResultData['search']['nodes'] as List<dynamic>
                     ];
 
                     // to avoid alot of work, lets just update the list of repos in returned
                     // data with new data, this also ensure we have the endCursor already set
                     // correctlty
-                    res['search']['nodes'] = repos;
+                    fetchMoreResultData['search']['nodes'] = repos;
 
-                    return res;
+                    return fetchMoreResultData;
                   },
                 );
 

--- a/packages/graphql_flutter/example/lib/fetchmore/main.dart
+++ b/packages/graphql_flutter/example/lib/fetchmore/main.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+import '../graphql_operation/queries/readRepositories.dart' as queries;
+
+// to run the example, create a file ../local.dart with the content:
+// const String YOUR_PERSONAL_ACCESS_TOKEN =
+//    '<YOUR_PERSONAL_ACCESS_TOKEN>';
+// ignore: uri_does_not_exist
+import '../local.dart';
+
+class FetchMoreWidgetScreen extends StatelessWidget {
+  const FetchMoreWidgetScreen() : super();
+
+  @override
+  Widget build(BuildContext context) {
+    final HttpLink httpLink = HttpLink(
+      uri: 'https://api.github.com/graphql',
+    );
+
+    final AuthLink authLink = AuthLink(
+      // ignore: undefined_identifier
+      getToken: () async => 'Bearer $YOUR_PERSONAL_ACCESS_TOKEN',
+    );
+
+    Link link = authLink.concat(httpLink);
+
+    final ValueNotifier<GraphQLClient> client = ValueNotifier<GraphQLClient>(
+      GraphQLClient(
+        cache: InMemoryCache(),
+        link: link,
+      ),
+    );
+
+    return GraphQLProvider(
+      client: client,
+      child: const CacheProvider(
+        child: MyHomePage(title: 'GraphQL Pagination'),
+      ),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({
+    Key key,
+    this.title,
+  }) : super(key: key);
+
+  final String title;
+
+  @override
+  _MyHomePageState createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  String _searchQuery = "flutter";
+  int nRepositories = 10;
+
+  void changeQuery(String query) {
+    setState(() {
+      print(query);
+      _searchQuery = query ?? "flutter";
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          mainAxisSize: MainAxisSize.max,
+          children: <Widget>[
+            TextField(
+              decoration: const InputDecoration(
+                labelText: 'Search Query',
+              ),
+              keyboardType: TextInputType.text,
+              onSubmitted: changeQuery,
+            ),
+            Query(
+              options: QueryOptions(
+                document: queries.searchRepositories,
+                variables: <String, dynamic>{
+                  'nRepositories': nRepositories,
+                  'query': _searchQuery,
+                  'cursor':
+                      null // set cursor to null so as to start at the beginning
+                },
+                //pollInterval: 10,
+              ),
+              builder: (QueryResult result, {refetch, FetchMore fetchMore}) {
+                if (result.loading && result.data == null) {
+                  return const Center(
+                    child: CircularProgressIndicator(),
+                  );
+                }
+
+                if (result.hasErrors) {
+                  return Text('\nErrors: \n  ' + result.errors.join(',\n  '));
+                }
+
+                if (result.data == null && result.errors == null) {
+                  return const Text(
+                      'Both data and errors are null, this is a known bug after refactoring, you might forget to set Github token');
+                }
+
+                // result.data can be either a [List<dynamic>] or a [Map<String, dynamic>]
+                final List<dynamic> repositories =
+                    (result.data['search']['nodes'] as List<dynamic>);
+
+                final Map pageInfo = result.data['search']['pageInfo'];
+
+                FetchMoreOptions opts = FetchMoreOptions(
+                  variables: {'cursor': pageInfo['endCursor']},
+                  updateQuery: (prev, res) {
+                    // this is where you combine your previous data and response
+                    // in case of this, we want to display previous repos plus next repos
+                    // so, we combine data in both into a single list of repos
+                    final List<dynamic> repos = [
+                      ...prev['search']['nodes'] as List<dynamic>,
+                      ...res['search']['nodes'] as List<dynamic>
+                    ];
+
+                    // to avoid alot of work, lets just update the list of repos in returned
+                    // data with new data, this also ensure we have the endCursor already set
+                    // correctlty
+                    res['search']['nodes'] = repos;
+
+                    return res;
+                  },
+                );
+
+                return Expanded(
+                  child: ListView(
+                    children: <Widget>[
+                      for (var repository in repositories)
+                        ListTile(
+                          leading: (repository['viewerHasStarred'] as bool)
+                              ? const Icon(
+                                  Icons.star,
+                                  color: Colors.amber,
+                                )
+                              : const Icon(Icons.star_border),
+                          title: Text(repository['name'] as String),
+                        ),
+                      if (result.loading)
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            CircularProgressIndicator(),
+                          ],
+                        ),
+                      RaisedButton(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            Text("Load More"),
+                          ],
+                        ),
+                        onPressed: () {
+                          fetchMore(opts);
+                        },
+                      )
+                    ],
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/graphql_flutter/example/lib/graphql_operation/queries/readRepositories.dart
+++ b/packages/graphql_flutter/example/lib/graphql_operation/queries/readRepositories.dart
@@ -13,6 +13,32 @@ const String readRepositories = r'''
   }
 ''';
 
+const String searchRepositories = r'''
+  query SearchRepositories($nRepositories: Int!, $query: String!, $cursor: String) {
+    search(last: $nRepositories, query: $query, type: REPOSITORY, after: $cursor) {
+      nodes {
+        __typename
+        ... on Repository {
+          name
+          shortDescriptionHTML
+          viewerHasStarred
+          stargazers {
+            totalCount
+          }
+          forks {
+            totalCount
+          }
+          updatedAt
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+''';
+
 const String testSubscription = r'''
 		subscription test {
 	    deviceChanged(id: 2) {

--- a/packages/graphql_flutter/example/lib/graphql_widget/main.dart
+++ b/packages/graphql_flutter/example/lib/graphql_widget/main.dart
@@ -103,7 +103,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
                 //pollInterval: 10,
               ),
-              builder: (QueryResult result, {VoidCallback refetch}) {
+              builder: (QueryResult result, {refetch, fetchMore}) {
                 if (result.loading) {
                   return const Center(
                     child: CircularProgressIndicator(),

--- a/packages/graphql_flutter/example/lib/main.dart
+++ b/packages/graphql_flutter/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import './graphql_bloc/main.dart' show GraphQLBlocPatternScreen;
 import './graphql_widget/main.dart' show GraphQLWidgetScreen;
+import 'fetchmore/main.dart';
 
 void main() => runApp(
       MaterialApp(
@@ -36,6 +37,18 @@ void main() => runApp(
                             MaterialPageRoute<GraphQLWidgetScreen>(
                               builder: (BuildContext context) =>
                                   const GraphQLWidgetScreen(),
+                            ),
+                          );
+                        },
+                      ),
+                      RaisedButton(
+                        child: const Text('Fetchmore (Pagination) Example'),
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute<FetchMoreWidgetScreen>(
+                              builder: (BuildContext context) =>
+                                  const FetchMoreWidgetScreen(),
                             ),
                           );
                         },

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -80,6 +80,16 @@ class QueryState extends State<Query> {
       );
     }
 
+    // stream new results with a query loader
+    QueryResult currentResults = QueryResult(
+      data: observableQuery.latestResult.data,
+      loading: true,
+      errors: observableQuery.latestResult.errors,
+      optimistic: observableQuery.latestResult.optimistic,
+    );
+
+    observableQuery.addResult(currentResults);
+
     final GraphQLClient client = GraphQLProvider.of(context).value;
     assert(client != null);
 

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -8,7 +8,7 @@ import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 typedef BoolCallback = bool Function();
 
 // method to call from widget to fetchmore queries
-typedef FetchMore = dynamic Function(FetchMoreOptions options);
+typedef dynamic FetchMore(FetchMoreOptions options);
 
 typedef QueryBuilder = Widget Function(
   QueryResult result, {
@@ -96,11 +96,13 @@ class QueryState extends State<Query> {
     var results = await client.query(combinedOptions);
 
     // combine the query with the new query, using the fucntion provided by the user
-    var combineResults =
-        options.updateQuery(observableQuery.latestResult, results);
+    var combineData =
+        options.updateQuery(observableQuery.latestResult.data, results.data);
+
+    results.data = combineData;
 
     // stream the new results and rebuild
-    observableQuery.addResult(combineResults);
+    observableQuery.addResult(results);
   }
 
   void _initQuery() {
@@ -144,6 +146,7 @@ class QueryState extends State<Query> {
         return widget?.builder(
           snapshot.data,
           refetch: observableQuery.refetch,
+          fetchMore: fetchMore,
         );
       },
     );

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -8,8 +8,7 @@ authors:
 - Michael Joseph Rosenthal <rosenthalm93@gmail.com>
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
 dependencies:
-  graphql:
-    path: ../graphql
+  graphql: ^1.1.1-beta.8
   flutter:
     sdk: flutter
   meta: ^1.1.6

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -8,7 +8,8 @@ authors:
 - Michael Joseph Rosenthal <rosenthalm93@gmail.com>
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
 dependencies:
-  graphql: ^1.1.1-beta.8
+  graphql:
+    path: ../graphql
   flutter:
     sdk: flutter
   meta: ^1.1.6
@@ -22,4 +23,4 @@ dev_dependencies:
     sdk: flutter
   test: ^1.5.3
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.2.2 <3.0.0'


### PR DESCRIPTION
This adds the fetch more feature for queries within the Query Widget. It is an early version, so am open to ideas and suggestions, especially on some use cases i may not have foreseen.

### Breaking changes

This breaks the current query builder method, by exposing a fetchMore method which can be called within the builder to fetch more documents.

So instead of 
```dart
...
builder: (QueryResult result, {refetch}) {
  ...
}
...
```

it will be:

```dart
...
builder: (QueryResult result, {refetch, FetchMore fetchMore}) {
  ...
}
...
```
#### Fixes / Enhancements

- Attempts to solve [this](https://github.com/zino-app/graphql-flutter/issues/144).

#### Docs

For the time being, i have update the `graphql-flutter` [example](https://github.com/mainawycliffe/graphql-flutter/blob/fetchmore/packages/graphql_flutter/example/lib/fetchmore/main.dart), to add a third example demonstrating this feature in action. Once we have addressed all concerns that may arise , i will update docs and tests accordingly.
