### PR TITLE
Prevent query from running again if not necessary

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -61,7 +61,10 @@ class QueryState extends State<Query> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _initQuery();
+    if (observableQuery == null ||
+        !observableQuery.options.areEqualTo(_options)) {
+      _initQuery();
+    }
   }
 
   @override


### PR DESCRIPTION
Whenever I push a new screen on top of another one that has a query the bottom one also updates it's content.
However, when I pop to this screen the query is not rerun (I don't know if this was wanted).
Anyway, I think the old implementation is really bad because if I have 10 screens on top on one another (user opens a post then opens creator's page then open another post) then I will have 10 queries running all the time.

I don't know if it was intentional to depend on another part of the library to change (like if you changed the client link) but then it would have to be done in another way.

I've been using it like this and haven't found any problems so far.

Describe the purpose of the pull request.

### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
