### PR TITLE
fix(client): error handling

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -233,6 +233,8 @@ class QueryManager {
     // so try/catch to avoid "could not access message"
     try {
       errorMessage = error.message as String;
+      assert(errorMessage != null);
+      assert(errorMessage.isNotEmpty);
     } catch (e) {
       throw error;
     }

--- a/packages/graphql/test/graphql_client_test.dart
+++ b/packages/graphql/test/graphql_client_test.dart
@@ -128,7 +128,32 @@ void main() {
         expect(nodes[2]['viewerHasStarred'], false);
         return;
       });
-//    test('failed query because of network', {});
+
+      test('failed query because of an exception with null string', () async {
+        final e = Exception();
+        when(mockHttpClient.send(any)).thenAnswer((_) async {
+          throw e;
+        });
+
+        final Future<QueryResult> r = graphQLClientClient
+            .query(WatchQueryOptions(document: readRepositories));
+
+        await expectLater(r, throwsA(e));
+        return;
+      });
+
+      test('failed query because of an exception with empty string', () async {
+        final e = Exception('');
+        when(mockHttpClient.send(any)).thenAnswer((_) async {
+          throw e;
+        });
+
+        final Future<QueryResult> r = graphQLClientClient
+            .query(WatchQueryOptions(document: readRepositories));
+
+        await expectLater(r, throwsA(e));
+        return;
+      });
 //    test('failed query because of because of error response', {});
 //    test('failed query because of because of invalid response', () {
 //      String responseBody =


### PR DESCRIPTION
Fixing https://github.com/zino-app/graphql-flutter/issues/355 that some errors/exceptions that is not related to GraphQL are still coerced and have no useful information.

Describe the purpose of the pull request.

### Breaking changes

- Should not be a breaking change, because previously, we already expect some exceptions/errors to be thrown directly