### PR TITLE
Docs: minor ReadMe update, to use version 2 instead of 1

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -18,7 +18,7 @@ First, depend on this package:
 
 ```yaml
 dependencies:
-  graphql: ^1.0.1-beta
+  graphql: ^2.0.0
 ```
 
 And then import it inside your dart code:
@@ -44,7 +44,7 @@ final AuthLink _authLink = AuthLink(
     getToken: () async => 'Bearer $YOUR_PERSONAL_ACCESS_TOKEN',
 );
 
-final Link _link = _authLink.concat(_httpLink as Link);
+final Link _link = _authLink.concat(_httpLink);
 
 final GraphQLClient _client = GraphQLClient(
         cache: InMemoryCache(),

--- a/packages/graphql_flutter/README.md
+++ b/packages/graphql_flutter/README.md
@@ -14,19 +14,19 @@
 
 ## Table of Contents
 
-- [Installation](#installation)
-- [Usage](#usage)
-  - [GraphQL Provider](#graphql-provider)
-  - [Offline Cache](#offline-cache)
-    - [Normalization](#normalization)
-    - [Optimism](#optimism)
-  - [Queries](#queries)
-  - [Mutations](#mutations)
-    - [Mutations with optimism](#mutations-with-optimism)
-  - [Subscriptions (Experimental)](#subscriptions-experimental)
-  - [GraphQL Consumer](#graphql-consumer)
-  - [Graphql Upload](#graphql-upload)
-- [Roadmap](#roadmap)
+- [Installation](#Installation)
+- [Usage](#Usage)
+  - [GraphQL Provider](#GraphQL-Provider)
+  - [Offline Cache](#Offline-Cache)
+    - [Normalization](#Normalization)
+    - [Optimism](#Optimism)
+  - [Queries](#Queries)
+  - [Mutations](#Mutations)
+    - [Mutations with optimism](#Mutations-with-optimism)
+  - [Subscriptions (Experimental)](#Subscriptions-Experimental)
+  - [GraphQL Consumer](#GraphQL-Consumer)
+  - [GraphQL Upload](#GraphQL-Upload)
+- [Roadmap](#Roadmap)
 
 ## Installation
 
@@ -34,7 +34,7 @@ First, depends on the library by adding this to your packages `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  graphql_flutter: ^1.0.0
+  graphql_flutter: ^2.0.0
 ```
 
 Now inside your Dart code, you can import it.
@@ -65,7 +65,7 @@ void main() {
     // getToken: () => 'Bearer <YOUR_PERSONAL_ACCESS_TOKEN>',
   );
 
-  final Link link = authLink.concat(httpLink as Link);
+  final Link link = authLink.concat(httpLink);
 
   ValueNotifier<GraphQLClient> client = ValueNotifier(
     GraphQLClient(
@@ -464,14 +464,14 @@ This is currently our roadmap, please feel free to request additions/changes.
 
 | Feature                 | Progress |
 | :---------------------- | :------: |
-| Queries                 |    ✅    |
-| Mutations               |    ✅    |
-| Subscriptions           |    ✅    |
-| Query polling           |    ✅    |
-| In memory cache         |    ✅    |
-| Offline cache sync      |    ✅    |
-| GraphQL pload           |    ✅    |
-| Optimistic results      |    ✅    |
+| Queries                 |    ✅     |
+| Mutations               |    ✅     |
+| Subscriptions           |    ✅     |
+| Query polling           |    ✅     |
+| In memory cache         |    ✅     |
+| Offline cache sync      |    ✅     |
+| GraphQL pload           |    ✅     |
+| Optimistic results      |    ✅     |
 | Client state management |    🔜    |
 | Modularity              |    🔜    |
 


### PR DESCRIPTION
This PR updates ReadMe installation instruction for both packages to use version `^2.0.0` instead of one. 