### PR TITLE
Pass the storage path to the InMemoryCache as a parameter

### DIFF
--- a/packages/graphql_flutter/lib/src/caches.dart
+++ b/packages/graphql_flutter/lib/src/caches.dart
@@ -10,7 +10,9 @@ final FutureOr<String> flutterStoragePrefix =
     (() async => (await getApplicationDocumentsDirectory()).path)();
 
 class InMemoryCache extends client.InMemoryCache {
-  InMemoryCache() : super(storagePrefix: flutterStoragePrefix);
+  InMemoryCache({
+    FutureOr<String> storagePrefix,
+  }) : super(storagePrefix: storagePrefix ?? flutterStoragePrefix);
 }
 
 class NormalizedInMemoryCache extends client.NormalizedInMemoryCache {


### PR DESCRIPTION
Allow to passing the storage path as a parameter of the InMemoryCache initializer.

#### Fixes / Enhancements

- Fixed a problem on our tests where the dependency of the "path_provider" package throws an error.
- Added the possibility to save the cache to a directory other than the documents directory.