### PR TITLE
Crash-Fix for when the server sends a map instead of a string

### DIFF
--- a/packages/graphql/lib/src/core/graphql_error.dart
+++ b/packages/graphql/lib/src/core/graphql_error.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 /// A location where a [GraphQLError] appears.
 class Location {
   /// Constructs a [Location] from a JSON map.
@@ -27,7 +28,7 @@ class GraphQLError {
 
   /// Constructs a [GraphQLError] from a JSON map.
   GraphQLError.fromJSON(this.raw)
-      : message = raw['message'] as String,
+      : message = raw['message'] is Map<String, dynamic> ? new JsonEncoder.withIndent(" ").convert(raw['message']) : raw['message'] as String,
         locations = raw['locations'] is List<Map<String, int>>
             ? List<Location>.from(
                 (raw['locations'] as List<Map<String, int>>).map<Location>(

--- a/packages/graphql/lib/src/core/graphql_error.dart
+++ b/packages/graphql/lib/src/core/graphql_error.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 /// A location where a [GraphQLError] appears.
 class Location {
   /// Constructs a [Location] from a JSON map.
@@ -28,7 +27,7 @@ class GraphQLError {
 
   /// Constructs a [GraphQLError] from a JSON map.
   GraphQLError.fromJSON(this.raw)
-      : message = raw['message'] is Map<String, dynamic> ? new JsonEncoder.withIndent(" ").convert(raw['message']) : raw['message'] as String,
+      : message = raw['message'] is String ? raw['message'] as String : 'Invalid server response: message property needs to be of type String',
         locations = raw['locations'] is List<Map<String, int>>
             ? List<Location>.from(
                 (raw['locations'] as List<Map<String, int>>).map<Location>(


### PR DESCRIPTION
Describe the purpose of the pull request.
My Apollo Server sends a map error instead of string. Which causes the library to crash.

```
response: / {
  errors: [
    {
      message: { statusCode: 401, error: 'Unauthorized' },
      locations: [ { line: 2, column: 13 } ],
      path: [ 'currentUser' ],
      extensions: {
        code: 'INTERNAL_SERVER_ERROR',
        exception: {
          response: { statusCode: 401, error: 'Unauthorized' },
          status: 401,
...
```
### Breaking changes

There are no breaking changes

#### Fixes / Enhancements

Fixes the following error:
```
[VERBOSE-2:ui_dart_state.cc(148)] Unhandled Exception: type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'String' in type cast
#0      QueryManager._attemptToWrapError (package:graphql/src/core/query_manager.dart:237:7)
#1      QueryManager._resolveQueryOnNetwork (package:graphql/src/core/query_manager.dart:140:28)
<asynchronous suspension>
#2      QueryManager.fetchQueryAsMultiSourceResult (package:graphql/src/core/query_manager.dart:90:17)
#3      ObservableQuery.fetchResults (package:graphql/src/core/observable_query.dart:116:22)
#4      new ObservableQuery (package:graphql/src/core/observable_query.dart:31:7)
#5      QueryManager.watchQuery (package:graphql/src/core/query_manager.dart:45:45)
#6      GraphQLClient.watchQuery (package:graphql/src/graphql_client.dart:38:25)
#7      QueryState._initQuery (package:graphql_flutter/src/widgets/query.dart:58:30)
#8      QueryState.didChangeDependencies (package:graphql_flutter/src/widgets/query.dart:64:5)
#9      StatefulElement._fi<…>
```

It will now check if it is a Map object and converts it with JsonEncoder if needed.

#### Docs

No doc changes needed
