### PR TITLE
Weekly release trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,31 @@ jobs:
             cd packages/graphql_flutter
             pub publish -f
 workflows:
+  weekly:
+    triggers:
+      - schedule:
+          cron: "0 21 * * 1"
+          filters:
+            branches:
+              only:
+                - master
+                - beta
+    jobs:
+      - dependencies
+      - lint:
+          requires:
+            - dependencies
+      - coverage:
+          requires:
+            - dependencies
+      - release:
+          requires:
+            - dependencies
+            - lint
+            - coverage
+      - sync_with_beta:
+          requires:
+            - release
   default:
     jobs:
       - dependencies:


### PR DESCRIPTION
This PR add a weekly release trigger. If there are any new commits it releases a new version.

The release schedule is set on Monday morning 9am. This is open to debate.