### PR TITLE
Nightly release trigger 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,30 @@ jobs:
             cd packages/graphql_flutter
             pub publish -f
 workflows:
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - beta
+    jobs:
+      - dependencies
+      - lint:
+          requires:
+            - dependencies
+      - coverage:
+          requires:
+            - dependencies
+      - release:
+          requires:
+            - dependencies
+            - lint
+            - coverage
+      - sync_with_beta:
+          requires:
+            - release
   weekly:
     triggers:
       - schedule:
@@ -209,7 +233,6 @@ workflows:
             branches:
               only:
                 - master
-                - beta
     jobs:
       - dependencies
       - lint:
@@ -244,23 +267,6 @@ workflows:
           filters:
             tags:
               ignore: /^.*$/
-      - release:
-          requires:
-            - dependencies
-            - lint
-            - coverage
-          filters:
-            branches:
-              only:
-                - master
-                - beta
-      - sync_with_beta:
-          requires:
-            - release
-          filters:
-            branches:
-              only:
-                - master
       - publish:
           requires:
             - dependencies 


### PR DESCRIPTION
This PR adds a nightly release cycle on our beta branch. Triggered each night at 00:00.

Previously releases got trigged by committing to, or merging into, the `beta` and `master` branches. Which is no longer needed, because both branches will be released on cycles. This PR therefor removes that old functionality.

