### PR TITLE
Fetchmore, json encoding, and query var change patches 

### DIFF
--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -155,11 +155,18 @@ class ObservableQuery {
     QueryResult fetchMoreResult = await queryManager.query(combinedOptions);
 
     try {
+      // combine the query with the new query, using the function provided by the user
       fetchMoreResult.data = fetchMoreOptions.updateQuery(
         latestResult.data,
         fetchMoreResult.data,
       );
       assert(fetchMoreResult.data != null, 'updateQuery result cannot be null');
+      // stream the new results and rebuild
+      queryManager.addQueryResult(
+        queryId,
+        fetchMoreResult,
+        writeToCache: true,
+      );
     } catch (error) {
       if (fetchMoreResult.hasErrors) {
         // because the updateQuery failure might have been because of these errors,
@@ -168,16 +175,17 @@ class ObservableQuery {
           ...(latestResult.errors ?? const []),
           ...fetchMoreResult.errors
         ];
-        addResult(latestResult);
+        queryManager.addQueryResult(
+          queryId,
+          latestResult,
+          writeToCache: true,
+        );
+
         return;
       } else {
         rethrow;
       }
     }
-
-    // combine the query with the new query, using the fucntion provided by the user
-    // stream the new results and rebuild
-    addResult(fetchMoreResult);
   }
 
   /// add a result to the stream,

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -104,6 +104,13 @@ class ObservableQuery {
   void onListen() {
     if (_latestWasEagerlyFetched) {
       _latestWasEagerlyFetched = false;
+
+      // eager results are resolved synchronously,
+      // so we have to add them manually now that
+      // the stream is available
+      if (!controller.isClosed && latestResult != null) {
+        controller.add(latestResult);
+      }
       return;
     }
     if (options.fetchResults) {

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -136,7 +136,7 @@ class ObservableQuery {
     assert(fetchMoreOptions.updateQuery != null);
 
     final combinedOptions = QueryOptions(
-      fetchPolicy: FetchPolicy.networkOnly,
+      fetchPolicy: FetchPolicy.noCache,
       errorPolicy: options.errorPolicy,
       document: fetchMoreOptions.document ?? options.document,
       context: options.context,

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -245,8 +245,19 @@ class QueryManager {
   }
 
   /// Add a result to the query specified by `queryId`, if it exists
-  void addQueryResult(String queryId, QueryResult queryResult) {
+  void addQueryResult(
+    String queryId,
+    QueryResult queryResult, {
+    bool writeToCache = false,
+  }) {
     final ObservableQuery observableQuery = getQuery(queryId);
+    if (writeToCache) {
+      cache.write(
+        observableQuery.options.toKey(),
+        queryResult.data,
+      );
+    }
+
     if (observableQuery != null && !observableQuery.controller.isClosed) {
       observableQuery.addResult(queryResult);
     }

--- a/packages/graphql/lib/src/core/raw_operation_data.dart
+++ b/packages/graphql/lib/src/core/raw_operation_data.dart
@@ -58,7 +58,8 @@ class RawOperationData {
       if (isIoFile(object)) {
         return object.path;
       }
-      return object;
+      // default toEncodable behavior
+      return object.toJson();
     });
 
     return '$document|$encodedVariables|$_identifier';

--- a/packages/graphql_flutter/README.md
+++ b/packages/graphql_flutter/README.md
@@ -249,7 +249,7 @@ FetchMoreOptions opts = FetchMoreOptions(
     ];
 
     // to avoid a lot of work, lets just update the list of repos in returned
-    // data with new data, this also ensure we have the endCursor already set
+    // data with new data, this also ensures we have the endCursor already set
     // correctly
     fetchMoreResultData['search']['nodes'] = repos;
 

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -86,6 +86,7 @@ class QueryState extends State<Query> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<QueryResult>(
+      key: Key(observableQuery?.options?.toKey()),
       initialData: observableQuery?.latestResult ?? QueryResult(loading: true),
       stream: observableQuery.stream,
       builder: (


### PR DESCRIPTION
closes #389, #386, #374, #351 

#### Fixes / Enhancements
- default to `object.toJson()` in `toKey()` (#374)
- use `noCache` when calling `fetchMore` to avoid cache writes/normalization
- add mechanism to `writeToCache` in `addQueryResult` so `fetchMore` now calls:
```dart
      queryManager.addQueryResult(
        queryId,
        fetchMoreResult,
        writeToCache: true,
      );
```
- Added the eager result to the stream `onListen` (https://github.com/zino-app/graphql-flutter/issues/351#issuecomment-524975586)
- Added a `key` to Query` to reset the stream (initial renders with new variables would have stale data otherwise)