### PR TITLE
Client-level default policies

### DIFF
--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -10,6 +10,60 @@ import 'package:graphql/src/link/link.dart';
 import 'package:graphql/src/link/operation.dart';
 import 'package:meta/meta.dart';
 
+/// The default [Policies] to set for each client action
+class DefaultPolicies {
+  /// The default [Policies] for watchQuery.
+  /// Defaults to
+  /// ```
+  /// Policies(
+  ///   FetchPolicy.cacheAndNetwork,
+  ///   ErrorPolicy.none,
+  /// )
+  /// ```
+  Policies watchQuery;
+
+  /// The default [Policies] for query.
+  /// Defaults to
+  /// ```
+  /// Policies(
+  ///   FetchPolicy.cacheFirst,
+  ///   ErrorPolicy.none,
+  /// )
+  /// ```
+  Policies query;
+
+  /// The default [Policies] for mutate.
+  /// Defaults to
+  /// ```
+  /// Policies(
+  ///   FetchPolicy.networkOnly,
+  ///   ErrorPolicy.none,
+  /// )
+  /// ```
+  Policies mutate;
+  DefaultPolicies({
+    Policies watchQuery,
+    Policies query,
+    Policies mutate,
+  })  : this.watchQuery = _watchQueryDefaults.withOverrides(watchQuery),
+        this.query = _queryDefaults.withOverrides(query),
+        this.mutate = _mutateDefaults.withOverrides(mutate);
+
+  static final _watchQueryDefaults = Policies.safe(
+    FetchPolicy.cacheAndNetwork,
+    ErrorPolicy.none,
+  );
+
+  static final _queryDefaults = Policies.safe(
+    FetchPolicy.cacheFirst,
+    ErrorPolicy.none,
+  );
+  static final _mutateDefaults = Policies.safe(
+    FetchPolicy.networkOnly,
+    ErrorPolicy.none,
+  );
+}
+
 /// The link is a [Link] over which GraphQL documents will be resolved into a [FetchResult].
 /// The cache is the initial [Cache] to use in the data store.
 class GraphQLClient {
@@ -17,12 +71,17 @@ class GraphQLClient {
   GraphQLClient({
     @required this.link,
     @required this.cache,
+    this.defaultPolicies,
   }) {
+    defaultPolicies ??= DefaultPolicies();
     queryManager = QueryManager(
       link: link,
       cache: cache,
     );
   }
+
+  /// The default [Policies] to set for each client action
+  DefaultPolicies defaultPolicies;
 
   /// The [Link] over which GraphQL documents will be resolved into a [FetchResult].
   final Link link;
@@ -35,18 +94,22 @@ class GraphQLClient {
   /// This registers a query in the [QueryManager] and returns an [ObservableQuery]
   /// based on the provided [WatchQueryOptions].
   ObservableQuery watchQuery(WatchQueryOptions options) {
+    options.policies =
+        defaultPolicies.watchQuery.withOverrides(options.policies);
     return queryManager.watchQuery(options);
   }
 
   /// This resolves a single query according to the [QueryOptions] specified and
   /// returns a [Future] which resolves with the [QueryResult] or throws an [Exception].
   Future<QueryResult> query(QueryOptions options) {
+    options.policies = defaultPolicies.query.withOverrides(options.policies);
     return queryManager.query(options);
   }
 
   /// This resolves a single mutation according to the [MutationOptions] specified and
   /// returns a [Future] which resolves with the [QueryResult] or throws an [Exception].
   Future<QueryResult> mutate(MutationOptions options) {
+    options.policies = defaultPolicies.mutate.withOverrides(options.policies);
     return queryManager.mutate(options);
   }
 

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -36,21 +36,17 @@ class QueryState extends State<Query> {
   ObservableQuery observableQuery;
 
   WatchQueryOptions get _options {
-    FetchPolicy fetchPolicy = widget.options.fetchPolicy;
-
-    if (fetchPolicy == FetchPolicy.cacheFirst) {
-      fetchPolicy = FetchPolicy.cacheAndNetwork;
-    }
+    final QueryOptions options = widget.options;
 
     return WatchQueryOptions(
-      document: widget.options.document,
-      variables: widget.options.variables,
-      fetchPolicy: fetchPolicy,
-      errorPolicy: widget.options.errorPolicy,
-      pollInterval: widget.options.pollInterval,
+      document: options.document,
+      variables: options.variables,
+      fetchPolicy: options.fetchPolicy,
+      errorPolicy: options.errorPolicy,
+      pollInterval: options.pollInterval,
       fetchResults: true,
-      context: widget.options.context,
-      optimisticResult: widget.options.optimisticResult,
+      context: options.context,
+      optimisticResult: options.optimisticResult,
     );
   }
 


### PR DESCRIPTION
Closes #366 

Allows users to configure the client with default `Policies` for `watchQuery`, `query`, and `mutate`

#### Fixes / Enhancements
* removes the override of `fetchPolicy` in `Query` and lets the `GraphQLClient `
* allows policies to be `null` on `*Options` objects, until they get merged with defaults (thus enabling the previous default behavior of the `Query` widget
