### PR TITLE
Async mutation callbacks, traversal patches

### DIFF
--- a/packages/graphql/lib/src/cache/lazy_cache_map.dart
+++ b/packages/graphql/lib/src/cache/lazy_cache_map.dart
@@ -1,4 +1,5 @@
 import 'dart:core';
+import 'package:quiver/core.dart' show hash3;
 
 import 'package:meta/meta.dart';
 
@@ -33,6 +34,14 @@ class LazyCacheMap extends LazyDereferencingMap {
     }
     return result;
   }
+
+  int get hashCode => hash3(_data, _dereference, cacheState);
+
+  bool operator ==(Object other) =>
+      other is LazyCacheMap &&
+      other._data == _data &&
+      other._dereference == _dereference &&
+      other.cacheState == cacheState;
 }
 
 /// Unwrap a given Object that could possibly be a lazy map

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -227,18 +227,16 @@ class ObservableQuery {
     callbacks ??= const <OnData>[];
     StreamSubscription<QueryResult> subscription;
 
-    subscription = stream.listen((QueryResult result) {
-      void handle(OnData callback) {
-        callback(result);
-      }
-
+    subscription = stream.listen((QueryResult result) async {
       if (!result.loading) {
-        callbacks.forEach(handle);
+        for (final callback in callbacks) {
+          await callback(result);
+        }
 
         queryManager.rebroadcastQueries();
 
         if (!result.optimistic) {
-          subscription.cancel();
+          await subscription.cancel();
           _onDataSubscriptions.remove(subscription);
 
           if (_onDataSubscriptions.isEmpty) {

--- a/packages/graphql/lib/src/utilities/traverse.dart
+++ b/packages/graphql/lib/src/utilities/traverse.dart
@@ -13,17 +13,17 @@ class Traversal {
     this.transformSideEffect,
     this.seenObjects,
   }) {
-    seenObjects ??= HashSet<int>();
+    seenObjects ??= HashSet<Object>();
   }
 
   Transform transform;
 
   /// An optional side effect to call when a node is transformed.
   SideEffect transformSideEffect;
-  HashSet<int> seenObjects;
+  HashSet<Object> seenObjects;
 
-  bool hasAlreadySeen(Object node) {
-    final bool wasAdded = seenObjects.add(node.hashCode);
+  bool alreadySeen(Object node) {
+    final bool wasAdded = seenObjects.add(node);
     return !wasAdded;
   }
 
@@ -31,9 +31,9 @@ class Traversal {
   Map<String, Object> traverseValues(Map<String, Object> node) {
     return node.map<String, Object>(
       (String key, Object value) => MapEntry<String, Object>(
-            key,
-            traverse(value),
-          ),
+        key,
+        traverse(value),
+      ),
     );
   }
 
@@ -41,7 +41,7 @@ class Traversal {
   // Stops recursing when a node is transformed (returns non-null)
   Object traverse(Object node) {
     final Object transformed = transform(node);
-    if (hasAlreadySeen(node)) {
+    if (alreadySeen(node)) {
       return transformed ?? node;
     }
     if (transformed != null) {

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   graphql_parser: ^1.1.3
   rxdart: ^0.22.0
   websocket: ^0.0.5
+  quiver: '>=2.0.0 <3.0.0'
 dev_dependencies:
   pedantic: <=1.7.99
   mockito: ^4.0.0

--- a/packages/graphql_flutter/lib/src/widgets/mutation.dart
+++ b/packages/graphql_flutter/lib/src/widgets/mutation.dart
@@ -80,7 +80,7 @@ class MutationState extends State<Mutation> {
     if (widget.onCompleted != null) {
       return (QueryResult result) {
         if (!result.loading && !result.optimistic) {
-          widget.onCompleted(result.data);
+          return widget.onCompleted(result.data);
         }
       };
     }
@@ -122,7 +122,7 @@ class MutationState extends State<Mutation> {
         if (result.optimistic) {
           return optimisticUpdate(result);
         } else {
-          widgetUpdate(cache, result);
+          return widgetUpdate(cache, result);
         }
       }
 


### PR DESCRIPTION
Fixes [async mutation callback handling](https://github.com/zino-app/graphql-flutter/issues/386#issuecomment-525359520) and bugs found with traversal

#### Fixes / Enhancements

- Fixed traversal - I had a mistaken understanding of `Object.hashCode`
- add `hashCode` and `==` support to `LazyCacheMap`
- Added an `await` to the `onData` callbacks so that `rebroadcastQueries` will have the right data on `async` updates. (this bit both me and @serendipity1004 and was hard to debug)