### PR TITLE
Fix policies comparison

### DIFF
--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 
 import 'package:graphql/src/utilities/helpers.dart';
@@ -41,7 +42,7 @@ enum ErrorPolicy {
   all,
 }
 
-class Policies {
+class Policies extends Equatable {
   /// Specifies the [FetchPolicy] to be used.
   FetchPolicy fetch;
 

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -7,6 +7,7 @@ authors:
 - Zino Hofmann <zino@zinoapp.com>
 - Michael Joseph Rosenthal <rosenthalm93@gmail.com>
 - TruongSinh Tran-Nguyen <i@truongsinh.pro>
+  - Maina Wycliffe <me@mainawycliffe.dev>
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql
 dependencies:
   meta: ^1.1.6

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   graphql_parser: ^1.1.3
   rxdart: ^0.22.0
   websocket: ^0.0.5
-  quiver: '>=2.0.0 <3.0.0'
+  equatable: ^0.1.5
 dev_dependencies:
   pedantic: <=1.7.99
   mockito: ^4.0.0

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -6,6 +6,7 @@ authors:
 - Eus Dima <eus@zinoapp.com>
 - Zino Hofmann <zino@zinoapp.com>
 - Michael Joseph Rosenthal <rosenthalm93@gmail.com>
+  - Maina Wycliffe <me@mainawycliffe.dev>
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
 dependencies:
   graphql: ^2.1.1-beta.2


### PR DESCRIPTION
This fixes a bug when comparing two `Policies` classes. Because of how dart classes work, two classes can only be equal if they are the same instance. I have used the Equatable package which overrides the default dart behavior and makes it possible to compare classed directly. 

This fixes the following [issue](https://github.com/zino-app/graphql-flutter/issues/351), allowing the loading property to be set to true if variables change. And possibly fixes this [issue](https://github.com/zino-app/graphql-flutter/issues/388).
