### PR TITLE
Reconnect websocket subscription

### DIFF
--- a/packages/graphql_flutter/example/pubspec.yaml
+++ b/packages/graphql_flutter/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^0.1.2
   rxdart: ^0.22.0
+  connectivity: ^0.4.4
   graphql_flutter:
     path: ..
 

--- a/packages/graphql_flutter/lib/src/widgets/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/subscription.dart
@@ -97,7 +97,6 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
             if (nsLookupResult.isNotEmpty &&
                 nsLookupResult[0].rawAddress.isNotEmpty) {
               _initSubscription();
-              _currentConnectivityResult = result;
             }
             // on exception -> no real connection, set current state to none
           } on SocketException catch (_) {

--- a/packages/graphql_flutter/lib/src/widgets/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/subscription.dart
@@ -45,6 +45,9 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
   dynamic _error;
   StreamSubscription<FetchResult> _subscription;
 
+  ConnectivityResult _currentConnectivityResult;
+  StreamSubscription<ConnectivityResult> _networkSubscription;
+
   void _initSubscription() {
     final GraphQLClient client = GraphQLProvider.of(context).value;
     assert(client != null);
@@ -74,9 +77,6 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
       onDone: _onDone,
     );
   }
-
-  ConnectivityResult _currentConnectivityResult;
-  StreamSubscription<ConnectivityResult> _networkSubscription;
 
   @override
   void initState() {

--- a/packages/graphql_flutter/lib/src/widgets/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/subscription.dart
@@ -80,7 +80,6 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
 
   @override
   void initState() {
-    debugPrint("INIT!");
     _networkSubscription = Connectivity()
         .onConnectivityChanged
         .listen((ConnectivityResult result) async {
@@ -88,6 +87,8 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
       if (_currentConnectivityResult == ConnectivityResult.none &&
           (result == ConnectivityResult.mobile ||
               result == ConnectivityResult.wifi)) {
+        _currentConnectivityResult = result;
+
         // android connectivitystate cannot be trusted
         // validate with nslookup
         if (Platform.isAndroid) {
@@ -98,12 +99,12 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
               _initSubscription();
               _currentConnectivityResult = result;
             }
+            // on exception -> no real connection, set current state to none
           } on SocketException catch (_) {
-            // debugPrint('not connected');
+            _currentConnectivityResult = ConnectivityResult.none;
           }
         } else {
           _initSubscription();
-          _currentConnectivityResult = result;
         }
       } else {
         _currentConnectivityResult = result;

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   path: ^1.6.2
   path_provider: ^1.1.0
   rxdart: ^0.22.0
+  connectivity: ^0.4.4
+
 dev_dependencies:
   pedantic: <=1.7.99
   mockito: ^4.0.0


### PR DESCRIPTION
Updating the subscription data when the user goes from offline to an online state with an ongoing subscription.

#### Fixes / Enhancements

Solution for issue #364 
Checks when to reconnect with the connectivity plugin. Calls _initSubscription when internet should be available again.

> Note that on Android, this does not guarantee connection to Internet. For instance, the app might > have wifi access but it might be a VPN or a hotel WiFi with no access.
Uses a nslookup on connectivitychange for android as solution to the shortcoming of the connectivity plugin.

It might be wise to make the android nslookup optional for users that want to reduce traffic, even if minimal.

#### Docs

No document change needed as this functionality is already implied with the flag autoReconnect.
