### PR TITLE
RefetchQuery should return a future

### DIFF
--- a/examples/starwars/lib/episode/hero_query.dart
+++ b/examples/starwars/lib/episode/hero_query.dart
@@ -33,7 +33,7 @@ class HeroForEpisode extends StatelessWidget {
       ),
       builder: (
         QueryResult result, {
-        BoolCallback refetch,
+        Future<QueryResult> Function() refetch,
         FetchMore fetchMore,
       }) {
         if (result.errors != null) {

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -76,7 +76,7 @@ class ObservableQuery {
   }
 
   /// Attempts to refetch, throwing error if not refetch safe
-  Future<QueryResult> refetch() async {
+  Future<QueryResult> refetch() {
     if (_isRefetchSafe) {
       return queryManager.refetchQuery(queryId);
     }

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -75,13 +75,12 @@ class ObservableQuery {
     return false;
   }
 
-  /// Attempts to refetch, returning `true` if successful
-  bool refetch() {
+  /// Attempts to refetch, throwing error if not refetch safe
+  Future<QueryResult> refetch() async {
     if (_isRefetchSafe) {
-      queryManager.refetchQuery(queryId);
-      return true;
+      return queryManager.refetchQuery(queryId);
     }
-    return false;
+    return Future<QueryResult>.error(Exception('Query is not refetch safe'));
   }
 
   bool get isRebroadcastSafe {

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -213,7 +213,7 @@ class QueryManager {
     return queryResult;
   }
 
-  Future<QueryResult> refetchQuery(String queryId) async {
+  Future<QueryResult> refetchQuery(String queryId) {
     final WatchQueryOptions options = queries[queryId].options;
     return fetchQuery(queryId, options);
   }

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -213,9 +213,9 @@ class QueryManager {
     return queryResult;
   }
 
-  void refetchQuery(String queryId) {
+  Future<QueryResult> refetchQuery(String queryId) async {
     final WatchQueryOptions options = queries[queryId].options;
-    fetchQuery(queryId, options);
+    return fetchQuery(queryId, options);
   }
 
   ObservableQuery getQuery(String queryId) {

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -5,14 +5,12 @@ import 'package:graphql/internal.dart';
 
 import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 
-typedef BoolCallback = bool Function();
-
 // method to call from widget to fetchmore queries
 typedef dynamic FetchMore(FetchMoreOptions options);
 
 typedef QueryBuilder = Widget Function(
   QueryResult result, {
-  BoolCallback refetch,
+  Future<QueryResult> Function() refetch,
   FetchMore fetchMore,
 });
 

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -6,11 +6,13 @@ import 'package:graphql/internal.dart';
 import 'package:graphql_flutter/src/widgets/graphql_provider.dart';
 
 // method to call from widget to fetchmore queries
-typedef dynamic FetchMore(FetchMoreOptions options);
+typedef FetchMore = dynamic Function(FetchMoreOptions options);
+
+typedef Refetch = Future<QueryResult> Function();
 
 typedef QueryBuilder = Widget Function(
   QueryResult result, {
-  Future<QueryResult> Function() refetch,
+  Refetch refetch,
   FetchMore fetchMore,
 });
 


### PR DESCRIPTION
This PR replaces #408. I deleted my forked repo, so I need to resubmit with changes.

@mainawycliffe, I updated other parts of the library that rely on `refetch` as [requested](https://github.com/zino-app/graphql-flutter/pull/408#pullrequestreview-285251449). However, I didn't update [this](https://github.com/zino-app/graphql-flutter/blob/633df3eda6c57a38aac6ee58baa4ac3f32630c95/packages/graphql/lib/src/scheduler/scheduler.dart#L60) since I'm not sure it's necessary.