### PR TITLE
AST-based operations

### DIFF
--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -145,7 +145,7 @@ class ObservableQuery {
     final combinedOptions = QueryOptions(
       fetchPolicy: FetchPolicy.noCache,
       errorPolicy: options.errorPolicy,
-      document: fetchMoreOptions.document ?? options.document,
+      documentNode: fetchMoreOptions.documentNode ?? options.documentNode,
       context: options.context,
       variables: {
         ...options.variables,

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -1,3 +1,5 @@
+import 'package:gql/ast.dart';
+import 'package:gql/language.dart';
 import 'package:meta/meta.dart';
 
 import 'package:graphql/src/utilities/helpers.dart';
@@ -47,6 +49,7 @@ class Policies {
 
   /// Specifies the [ErrorPolicy] to be used.
   ErrorPolicy error;
+
   Policies({
     this.fetch,
     this.error,
@@ -67,12 +70,18 @@ class Policies {
 /// Base options.
 class BaseOptions extends RawOperationData {
   BaseOptions({
-    @required String document,
+    @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
+        String document,
+    DocumentNode documentNode,
     Map<String, dynamic> variables,
     this.policies,
     this.context,
     this.optimisticResult,
-  }) : super(document: document, variables: variables);
+  }) : super(
+          document: document,
+          documentNode: documentNode,
+          variables: variables,
+        );
 
   /// An optimistic result to eagerly add to the operation stream
   Object optimisticResult;
@@ -81,6 +90,7 @@ class BaseOptions extends RawOperationData {
   Policies policies;
 
   FetchPolicy get fetchPolicy => policies.fetch;
+
   ErrorPolicy get errorPolicy => policies.error;
 
   /// Context to be passed to link execution chain.
@@ -90,7 +100,9 @@ class BaseOptions extends RawOperationData {
 /// Query options.
 class QueryOptions extends BaseOptions {
   QueryOptions({
-    @required String document,
+    @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
+        String document,
+    DocumentNode documentNode,
     Map<String, dynamic> variables,
     FetchPolicy fetchPolicy,
     ErrorPolicy errorPolicy,
@@ -100,6 +112,7 @@ class QueryOptions extends BaseOptions {
   }) : super(
           policies: Policies(fetch: fetchPolicy, error: errorPolicy),
           document: document,
+          documentNode: documentNode,
           variables: variables,
           context: context,
           optimisticResult: optimisticResult,
@@ -113,7 +126,9 @@ class QueryOptions extends BaseOptions {
 /// Mutation options
 class MutationOptions extends BaseOptions {
   MutationOptions({
-    @required String document,
+    @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
+        String document,
+    DocumentNode documentNode,
     Map<String, dynamic> variables,
     FetchPolicy fetchPolicy,
     ErrorPolicy errorPolicy,
@@ -121,6 +136,7 @@ class MutationOptions extends BaseOptions {
   }) : super(
           policies: Policies(fetch: fetchPolicy, error: errorPolicy),
           document: document,
+          documentNode: documentNode,
           variables: variables,
           context: context,
         );
@@ -129,7 +145,9 @@ class MutationOptions extends BaseOptions {
 // ObservableQuery options
 class WatchQueryOptions extends QueryOptions {
   WatchQueryOptions({
-    @required String document,
+    @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
+        String document,
+    DocumentNode documentNode,
     Map<String, dynamic> variables,
     FetchPolicy fetchPolicy,
     ErrorPolicy errorPolicy,
@@ -140,6 +158,7 @@ class WatchQueryOptions extends QueryOptions {
     Map<String, dynamic> context,
   }) : super(
           document: document,
+          documentNode: documentNode,
           variables: variables,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -164,7 +183,7 @@ class WatchQueryOptions extends QueryOptions {
     WatchQueryOptions a,
     WatchQueryOptions b,
   ) {
-    if (a.document != b.document) {
+    if (a.documentNode != b.documentNode) {
       return true;
     }
 
@@ -194,12 +213,29 @@ typedef dynamic UpdateQuery(
 /// options for fetchmore operations
 class FetchMoreOptions {
   FetchMoreOptions({
-    this.document,
+    @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
+        String document,
+    DocumentNode documentNode,
     this.variables = const <String, dynamic>{},
     @required this.updateQuery,
-  }) : assert(updateQuery != null);
+  })  : assert((document != null && documentNode == null) ||
+            (document == null && documentNode != null)),
+        assert(updateQuery != null),
+        documentNode = parseString(document);
 
-  final String document;
+  DocumentNode documentNode;
+
+  /// A string representation of [documentNode]
+  @Deprecated(
+      'The "document" option has been deprecated, use "documentNode" instead')
+  String get document => printNode(documentNode);
+
+  @Deprecated(
+      'The "document" option has been deprecated, use "documentNode" instead')
+  set document(value) {
+    documentNode = parseString(value);
+  }
+
   final Map<String, dynamic> variables;
 
   /// Strategy for merging the fetchMore result data

--- a/packages/graphql/lib/src/core/raw_operation_data.dart
+++ b/packages/graphql/lib/src/core/raw_operation_data.dart
@@ -1,29 +1,47 @@
 import 'dart:collection' show SplayTreeMap;
 import 'dart:convert' show json;
 
+import 'package:gql/ast.dart';
+import 'package:gql/language.dart';
 import 'package:http/http.dart';
-import 'package:meta/meta.dart';
 
-import 'package:graphql/src/utilities/get_from_ast.dart' show getOperationName;
+import 'package:graphql/src/utilities/get_from_ast.dart';
 import 'package:graphql/src/link/http/link_http_helper_deprecated_stub.dart'
     if (dart.library.io) 'package:graphql/src/link/http/link_http_helper_deprecated_io.dart';
 
 class RawOperationData {
   RawOperationData({
-    @required this.document,
+    @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
+        String document,
+    DocumentNode documentNode,
     Map<String, dynamic> variables,
     String operationName,
   })  : assert(
-          document != null,
-          'document option is required. You must specify your GraphQL document in the query options.',
+          (document != null && documentNode == null) ||
+              (document == null && documentNode != null),
+          '"document" or "documentNode" option is required. You must specify your GraphQL document in the query options.',
         ),
+        documentNode = documentNode ?? parseString(document),
         _operationName = operationName,
         variables = SplayTreeMap<String, dynamic>.of(
           variables ?? const <String, dynamic>{},
         );
 
   /// A GraphQL document that consists of a single query to be sent down to the server.
-  String document;
+  DocumentNode documentNode;
+
+  /// A string representation of [documentNode]
+  @Deprecated(
+    'The "document" option has been deprecated, use "documentNode" instead',
+  )
+  String get document => printNode(documentNode);
+
+  @Deprecated(
+    'The "document" option has been deprecated, use "documentNode" instead',
+  )
+  set document(value) {
+    documentNode = parseString(value);
+  }
 
   /// A map going from variable name to variable value, where the variables are used
   /// within the GraphQL query.
@@ -33,9 +51,7 @@ class RawOperationData {
 
   /// The last operation name appearing in the contained document.
   String get operationName {
-    // XXX there is a bug in the `graphql_parser` package, where this result might be
-    // null event though the operation name is present in the document
-    _operationName ??= getOperationName(document);
+    _operationName ??= getLastOperationName(documentNode);
     return _operationName;
   }
 
@@ -45,7 +61,7 @@ class RawOperationData {
   // TODO remove $document from key? A bit redundant, though that's not the worst thing
   String get _identifier {
     _documentIdentifier ??=
-        operationName ?? 'UNNAMED/' + document.hashCode.toString();
+        operationName ?? 'UNNAMED/' + documentNode.hashCode.toString();
     return _documentIdentifier;
   }
 

--- a/packages/graphql/lib/src/link/http/link_http.dart
+++ b/packages/graphql/lib/src/link/http/link_http.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import 'package:http/http.dart';
 import 'package:http_parser/http_parser.dart';
 
+import 'package:gql/language.dart';
 import 'package:graphql/src/utilities/helpers.dart' show notNull;
 import 'package:graphql/src/link/link.dart';
 import 'package:graphql/src/link/operation.dart';
@@ -300,7 +301,7 @@ HttpHeadersAndBody _selectHttpOptionsAndBody(
   }
 
   if (http.includeQuery) {
-    body['query'] = operation.document;
+    body['query'] = printNode(operation.documentNode);
   }
 
   return HttpHeadersAndBody(

--- a/packages/graphql/lib/src/link/operation.dart
+++ b/packages/graphql/lib/src/link/operation.dart
@@ -1,21 +1,25 @@
-import 'package:meta/meta.dart';
+import 'package:gql/ast.dart';
 
 import 'package:graphql/src/core/raw_operation_data.dart';
+import 'package:graphql/src/utilities/get_from_ast.dart';
 
 class Operation extends RawOperationData {
   Operation({
-    @required String document,
+    @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
+        String document,
+    DocumentNode documentNode,
     Map<String, dynamic> variables,
     this.extensions,
     String operationName,
   }) : super(
             document: document,
+            documentNode: documentNode,
             variables: variables,
             operationName: operationName);
 
   factory Operation.fromOptions(RawOperationData options) {
     return Operation(
-      document: options.document,
+      documentNode: options.documentNode,
       variables: options.variables,
     );
   }
@@ -38,7 +42,9 @@ class Operation extends RawOperationData {
     return result;
   }
 
-  bool get isSubscription =>
-      operationName != null &&
-      document.contains(RegExp(r'.*?subscription ' + operationName));
+  bool get isSubscription => isOfType(
+        OperationType.subscription,
+        documentNode,
+        operationName,
+      );
 }

--- a/packages/graphql/lib/src/websocket/messages.dart
+++ b/packages/graphql/lib/src/websocket/messages.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:gql/language.dart';
 import 'package:graphql/src/link/operation.dart';
 
 /// These messages represent the structures used for Client-server communication
@@ -78,7 +79,7 @@ class SubscriptionRequest extends JsonSerializable {
   @override
   Map<String, dynamic> toJson() => <String, dynamic>{
         'operationName': operation.operationName,
-        'query': operation.document,
+        'query': printNode(operation.documentNode),
         'variables': operation.variables,
       };
 }

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path: ^1.6.2
   http_parser: ^3.1.3
   uuid_enhanced: ^3.0.2
-  graphql_parser: ^1.1.3
+  gql: ^0.10.0
   rxdart: ^0.22.0
   websocket: ^0.0.5
   quiver: ">=2.0.0 <3.0.0"

--- a/packages/graphql/test/anonymous_operations_test.dart
+++ b/packages/graphql/test/anonymous_operations_test.dart
@@ -111,7 +111,7 @@ void main() {
           },
         );
         expect(await capt.finalize().bytesToString(),
-            r'{"operationName":null,"variables":{},"query":"{\n    viewer {\n      repositories(last: 42) {\n        nodes {\n          __typename\n          id\n          name\n          viewerHasStarred\n        }\n      }\n    }\n  }\n"}');
+            r'{"operationName":null,"variables":{},"query":"query {\n  viewer {\n    repositories(last: 42) {\n      nodes {\n        __typename\n        id\n        name\n        viewerHasStarred\n      }\n    }\n  }\n}"}');
 
         expect(r.exception, isNull);
         expect(r.data, isNotNull);
@@ -157,7 +157,7 @@ void main() {
           },
         );
         expect(await request.finalize().bytesToString(),
-            r'{"operationName":null,"variables":{},"query":"mutation {\n    action: addStar(input: {starrableId: \"some_repo\"}) {\n      starrable {\n        viewerHasStarred\n      }\n    }\n  }\n"}');
+            r'{"operationName":null,"variables":{},"query":"mutation {\n  action: addStar(input: {starrableId: \"some_repo\"}) {\n    starrable {\n      viewerHasStarred\n    }\n  }\n}"}');
 
         expect(response.exception, isNull);
         expect(response.data, isNotNull);

--- a/packages/graphql/test/graphql_client_test.dart
+++ b/packages/graphql/test/graphql_client_test.dart
@@ -115,7 +115,7 @@ void main() {
           },
         );
         expect(await capt.finalize().bytesToString(),
-            r'{"operationName":"ReadRepositories","variables":{"nRepositories":42},"query":"  query ReadRepositories($nRepositories: Int!) {\n    viewer {\n      repositories(last: $nRepositories) {\n        nodes {\n          __typename\n          id\n          name\n          viewerHasStarred\n        }\n      }\n    }\n  }\n"}');
+            r'{"operationName":"ReadRepositories","variables":{"nRepositories":42},"query":"query ReadRepositories($nRepositories: Int!) {\n  viewer {\n    repositories(last: $nRepositories) {\n      nodes {\n        __typename\n        id\n        name\n        viewerHasStarred\n      }\n    }\n  }\n}"}');
 
         expect(r.exception, isNull);
         expect(r.data, isNotNull);
@@ -193,7 +193,7 @@ void main() {
           },
         );
         expect(await request.finalize().bytesToString(),
-            r'{"operationName":"AddStar","variables":{},"query":"  mutation AddStar($starrableId: ID!) {\n    action: addStar(input: {starrableId: $starrableId}) {\n      starrable {\n        viewerHasStarred\n      }\n    }\n  }\n"}');
+            r'{"operationName":"AddStar","variables":{},"query":"mutation AddStar($starrableId: ID!) {\n  action: addStar(input: {starrableId: $starrableId}) {\n    starrable {\n      viewerHasStarred\n    }\n  }\n}"}');
 
         expect(response.exception, isNull);
         expect(response.data, isNotNull);

--- a/packages/graphql/test/multipart_upload_test.dart
+++ b/packages/graphql/test/multipart_upload_test.dart
@@ -77,7 +77,7 @@ void main() {
             '\r\ncontent-disposition: form-data; name="operations"\r\n\r\n');
         // operationName of unamed operations is "UNNAMED/" +  document.hashCode.toString()
         expectContinuationString(bodyBytes,
-            r'{"operationName":null,"variables":{"files":[null,null]},"query":"    mutation($files: [Upload!]!) {\n      multipleUpload(files: $files) {\n        id\n        filename\n        mimetype\n        path\n      }\n    }\n    "}');
+            r'{"operationName":null,"variables":{"files":[null,null]},"query":"mutation($files: [Upload!]!) {\n  multipleUpload(files: $files) {\n    id\n    filename\n    mimetype\n    path\n  }\n}"}');
         expectContinuationString(bodyBytes, '\r\n--');
         expectContinuationString(bodyBytes, boundary);
         expectContinuationString(bodyBytes,

--- a/packages/graphql/test/socket_client_test.dart
+++ b/packages/graphql/test/socket_client_test.dart
@@ -35,7 +35,9 @@ void main() {
       );
     });
     test('subscription data', () async {
-      final payload = SubscriptionRequest(Operation(document: 'empty'));
+      final payload = SubscriptionRequest(
+        Operation(document: 'subscription {}'),
+      );
       final waitForConnection = true;
       final subscriptionDataStream =
           socketClient.subscribe(payload, waitForConnection);
@@ -47,7 +49,7 @@ void main() {
       socketClient.socket.stream
           .where((message) =>
               message ==
-              '{"type":"start","id":"01020304-0506-4708-890a-0b0c0d0e0f10","payload":{"operationName":null,"query":"empty","variables":{}}}')
+              r'{"type":"start","id":"01020304-0506-4708-890a-0b0c0d0e0f10","payload":{"operationName":null,"query":"subscription {\n  \n}","variables":{}}}')
           .first
           .then((_) {
         socketClient.socket.add(jsonEncode({

--- a/packages/graphql/test/websocket_legacy_io_test.dart
+++ b/packages/graphql/test/websocket_legacy_io_test.dart
@@ -42,7 +42,9 @@ void main() {
         );
       });
       test('subscription data', () async {
-        final payload = SubscriptionRequest(Operation(document: 'empty'));
+        final payload = SubscriptionRequest(
+          Operation(document: 'subscription {}'),
+        );
         final waitForConnection = true;
         final subscriptionDataStream =
             socketClient.subscribe(payload, waitForConnection);
@@ -52,20 +54,26 @@ void main() {
 
         // ignore: unawaited_futures
         socketClient.stream
-            .where((message) =>
-                message ==
-                '{"type":"start","id":"01020304-0506-4708-890a-0b0c0d0e0f10","payload":{"operationName":null,"query":"empty","variables":{}}}')
+            .where(
+              (message) =>
+                  message ==
+                  r'{"type":"start","id":"01020304-0506-4708-890a-0b0c0d0e0f10","payload":{"operationName":null,"query":"subscription {\n  \n}","variables":{}}}',
+            )
             .first
-            .then((_) {
-          socketClient.socket.add(jsonEncode({
-            'type': 'data',
-            'id': '01020304-0506-4708-890a-0b0c0d0e0f10',
-            'payload': {
-              'data': {'foo': 'bar'},
-              'errors': ['error and data can coexist']
-            }
-          }));
-        });
+            .then(
+          (_) {
+            socketClient.socket.add(
+              jsonEncode({
+                'type': 'data',
+                'id': '01020304-0506-4708-890a-0b0c0d0e0f10',
+                'payload': {
+                  'data': {'foo': 'bar'},
+                  'errors': ['error and data can coexist']
+                }
+              }),
+            );
+          },
+        );
 
         await expectLater(
           subscriptionDataStream,


### PR DESCRIPTION
Allow creating operations out of AST.
This is a non-breaking transitional to enable AST-based links, local state resolvers.

This change add as slight performance reduction because documents must be printed to string before sending them over the network.
The remedy for that is building AST at build-time. Currently that is possible using `package:gql_code_gen`.