### PR TITLE
ci: bump the `semantic-release` version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       - checkout
       - run:
           name: Generate release tags
-          command: npx semantic-release@beta@16.0.0-beta.22
+          command: npx semantic-release@beta@16.0.0-beta.24
   sync_with_beta:
     docker: *node_environment
     steps:
@@ -218,9 +218,6 @@ workflows:
             - dependencies
             - lint
             - coverage
-      - sync_with_beta:
-          requires:
-            - release
   weekly:
     triggers:
       - schedule:


### PR DESCRIPTION
Nightly releases are currently broken because `semantic-release` is on a broken version. This PR bumps the version to fix the issue.

This PR also remove the `sync_with_beta` when running on the beta branch. Merging into your own branch does not work of course.