### PR TITLE
feat(client): support joining multiple links at once

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -55,6 +55,12 @@ final GraphQLClient _client = GraphQLClient(
 
 ```
 
+`Link.from` joins multiple links into a single link at once.
+
+```dart
+final Link _link = Link.from([_authLink, _httpLink]);
+```
+
 Once you have initialized a client, you can run queries and mutations.
 
 ### Query

--- a/packages/graphql/lib/src/link/link.dart
+++ b/packages/graphql/lib/src/link/link.dart
@@ -31,6 +31,11 @@ class Link {
 
   RequestHandler request;
 
+  static Link from(List<Link> links) {
+    assert(links.isNotEmpty);
+    return links.reduce((first, second) => first.concat(second));
+  }
+
   Link concat(Link next) => _concat(this, next);
 }
 

--- a/packages/graphql/test/link/link_test.dart
+++ b/packages/graphql/test/link/link_test.dart
@@ -1,0 +1,42 @@
+import 'package:graphql/src/link/link.dart';
+import 'package:graphql/src/link/operation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('link', () {
+    test('multiple', () {
+      String result = '';
+
+      final link1 = Link(
+        request: (Operation op, [NextLink forward]) {
+          result += '1';
+          return null;
+        },
+      );
+
+      final link2 = Link(
+        request: (Operation op, [NextLink forward]) {
+          result += '2';
+          return null;
+        },
+      );
+
+      final link3 = Link(
+        request: (Operation op, [NextLink forward]) {
+          result += '3';
+          return null;
+        },
+      );
+
+      expect(
+        execute(
+          link: Link.from([link1, link2, link3]),
+          operation: null,
+        ),
+        null,
+      );
+
+      expect(result, '123');
+    });
+  });
+}


### PR DESCRIPTION
This pull request adds `Link.from` so multiple links can be joined into a single link at once.

```dart
final Link link = Link.from([authLink, loggingLink, httpLink]);
```

#### Fixes / Enhancements

- Add `Link.from`.

#### Docs

- Document `Link.from` in README.md.
