### PR TITLE
feat(client): add error link

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -231,8 +231,21 @@ final MutationOptions options = MutationOptions(
 // ...
 ```
 
+## Links
 
+### `ErrorLink`
 
+Perform custom logic when a GraphQL or network error happens, such as logging or
+signing out.
+
+```dart
+final ErrorLink errorLink = ErrorLink(errorHandler: (ErrorResponse response) {
+  Operation operation = response.operation;
+  FetchResult result = response.fetchResult;
+  OperationException exception = response.exception;
+  print(exception.toString());
+});
+```
 
 [build-status-badge]: https://img.shields.io/circleci/build/github/zino-app/graphql-flutter.svg?style=flat-square
 [build-status-link]: https://circleci.com/gh/zino-app/graphql-flutter

--- a/packages/graphql/lib/client.dart
+++ b/packages/graphql/lib/client.dart
@@ -13,6 +13,7 @@ export 'package:graphql/src/core/query_result.dart';
 export 'package:graphql/src/exceptions/exceptions.dart';
 
 export 'package:graphql/src/link/auth/link_auth.dart';
+export 'package:graphql/src/link/error/link_error.dart';
 export 'package:graphql/src/link/http/link_http.dart';
 export 'package:graphql/src/link/link.dart';
 export 'package:graphql/src/link/web_socket/link_web_socket.dart';

--- a/packages/graphql/lib/src/link/error/link_error.dart
+++ b/packages/graphql/lib/src/link/error/link_error.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:graphql/src/link/link.dart';
+import 'package:graphql/src/link/operation.dart';
+import 'package:graphql/src/link/fetch_result.dart';
+import 'package:graphql/src/exceptions/exceptions.dart';
+import 'package:graphql/src/exceptions/graphql_error.dart';
+import 'package:graphql/src/exceptions/operation_exception.dart';
+
+typedef ErrorHandler = void Function(ErrorResponse);
+
+class ErrorResponse {
+  ErrorResponse({
+    this.operation,
+    this.fetchResult,
+    this.exception,
+  });
+
+  Operation operation;
+  FetchResult fetchResult;
+  OperationException exception;
+}
+
+class ErrorLink extends Link {
+  ErrorLink({
+    this.errorHandler,
+  }) : super(
+          request: (Operation operation, [NextLink forward]) {
+            StreamController<FetchResult> controller;
+
+            Future<void> onListen() async {
+              Stream stream = forward(operation).map((FetchResult fetchResult) {
+                if (fetchResult.errors != null) {
+                  List<GraphQLError> errors = fetchResult.errors
+                      .map((json) => GraphQLError.fromJSON(json))
+                      .toList();
+
+                  ErrorResponse response = ErrorResponse(
+                    operation: operation,
+                    fetchResult: fetchResult,
+                    exception: OperationException(graphqlErrors: errors),
+                  );
+
+                  errorHandler(response);
+                }
+                return fetchResult;
+              }).handleError((error) {
+                ErrorResponse response = ErrorResponse(
+                  operation: operation,
+                  exception: OperationException(
+                    clientException: translateFailure(error),
+                  ),
+                );
+
+                errorHandler(response);
+                throw error;
+              });
+
+              await controller.addStream(stream);
+              await controller.close();
+            }
+
+            controller = StreamController<FetchResult>(onListen: onListen);
+
+            return controller.stream;
+          },
+        );
+
+  ErrorHandler errorHandler;
+}

--- a/packages/graphql/test/link/error/link_error_test.dart
+++ b/packages/graphql/test/link/error/link_error_test.dart
@@ -1,0 +1,109 @@
+import "dart:async";
+import "dart:convert";
+
+import 'package:graphql/src/exceptions/exceptions.dart';
+import 'package:graphql/src/link/error/link_error.dart';
+import 'package:graphql/src/link/http/link_http.dart';
+import 'package:graphql/src/link/link.dart';
+import 'package:graphql/src/link/operation.dart';
+import "package:http/http.dart" as http;
+import "package:mockito/mockito.dart";
+import "package:test/test.dart";
+
+class MockClient extends Mock implements http.Client {}
+
+void main() {
+  group('error link', () {
+    MockClient client;
+    Operation query;
+    HttpLink httpLink;
+
+    setUp(() {
+      client = MockClient();
+      query = Operation(
+        document: 'query Operation {}',
+        operationName: 'Operation',
+      );
+      httpLink = HttpLink(
+        uri: '/graphql-test',
+        httpClient: client,
+      );
+    });
+
+    test('network error', () async {
+      bool called = false;
+
+      when(
+        client.send(any),
+      ).thenAnswer(
+        (_) => Future.value(
+          http.StreamedResponse(
+            Stream.fromIterable(
+              [utf8.encode('{}')],
+            ),
+            400,
+          ),
+        ),
+      );
+
+      final errorLink = ErrorLink(errorHandler: (response) {
+        if (response.exception.clientException != null) {
+          called = true;
+        }
+      });
+
+      Exception exception;
+
+      try {
+        await execute(
+          link: errorLink.concat(httpLink),
+          operation: query,
+        ).first;
+      } on Exception catch (e) {
+        exception = e;
+      }
+
+      expect(
+        exception,
+        const TypeMatcher<ClientException>(),
+      );
+      expect(
+        called,
+        true,
+      );
+    });
+
+    test('graphql error', () async {
+      bool called = false;
+
+      when(
+        client.send(any),
+      ).thenAnswer(
+        (_) => Future.value(
+          http.StreamedResponse(
+            Stream.fromIterable(
+              [utf8.encode('{"errors":[{"message":"error"}]}')],
+            ),
+            200,
+          ),
+        ),
+      );
+
+      final errorLink = ErrorLink(errorHandler: (response) {
+        if (response.exception.graphqlErrors != null) {
+          called = true;
+        }
+      });
+
+      await execute(
+        link: errorLink.concat(httpLink),
+        operation: query,
+      ).first;
+
+      expect(
+        called,
+        true,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #419 and #440.

Add `ErrorLink` which allows side effects such logging or signing out when a GraphQL or network error happens.

```dart
final ErrorLink errorLink = ErrorLink(errorHandler: (response) {
  if (response.graphQLErrors != null) {
    for (var error in response.graphQLErrors) {
      print('[GraphQL error]: Message: ${error['message']}, Location: ${error['locations']}, Path: ${error['path']}');
    }
  }

  if (response.networkError != null) {
    print('[Network error]: ${response.networkError}');
  }
});
```

Inspired by [apollo-link-error](https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-error).

#### Fixes / Enhancements

- Added `ErrorLink`.

#### Docs

- Document `ErrorLink` in README.md.
