### PR TITLE
cache.reset() added

### DIFF
--- a/packages/graphql/lib/src/cache/normalized_in_memory.dart
+++ b/packages/graphql/lib/src/cache/normalized_in_memory.dart
@@ -82,6 +82,11 @@ class NormalizedInMemoryCache extends InMemoryCache {
     }
   }
 
+  @override
+  void reset(){
+    data.clear();
+  }
+
   /*
     Dereferences object references,
     replacing them with cached instances

--- a/packages/graphql/test/normalized_in_memory_test.dart
+++ b/packages/graphql/test/normalized_in_memory_test.dart
@@ -229,4 +229,19 @@ void main() {
       expect(b.data, equals(cyclicalObjNormalizedB));
     });
   });
+
+  group('Resets cache correctly', (){
+    final NormalizedInMemoryCache cache = getTestCache();
+
+    test('resets cache correctly when cache.reset() is called', (){
+      cache.write(rawOperationKey, cyclicalObjOperationData);
+      final LazyCacheMap a = cache.read('A/1') as LazyCacheMap;
+      expect(a.data, equals(cyclicalObjNormalizedA));
+
+      cache.reset();
+
+      final resetA = cache.read('A/1');
+      expect(resetA, equals(null));
+    });
+  });
 }


### PR DESCRIPTION
Describe the purpose of the pull request.

#### Fixes / Enhancements

- exposed reset function on normalizedInMemoryCache and added test for it.
- previously requested as cache.clear() but cache.reset() function was already there in the abstract class. Did not want to break something so just went ahead with cache.reset();
