### PR TITLE
Allow sending of requests using a Link, outside of Widgets context

### DIFF
--- a/packages/graphql_flutter/lib/graphql_flutter.dart
+++ b/packages/graphql_flutter/lib/graphql_flutter.dart
@@ -2,6 +2,7 @@ library graphql_flutter;
 
 export 'package:graphql/client.dart'
     hide InMemoryCache, NormalizedInMemoryCache, OptimisticCache;
+export 'package:graphql/src/link/operation.dart' show Operation;
 
 export 'package:graphql_flutter/src/caches.dart';
 


### PR DESCRIPTION
Allows people to manually use a Link to send a request and get the result(s).

#### Fixes / Enhancements

- At this time, it seems we can only execute queries in the context of Flutter widgets. There are usecases that requires more than this, where outside of Widgets contexts, we need to run a query. This change allows just that by giving access to the `link.request()` which requires `Operation`.

#### Docs

- Exposes the `Operation` class
