### PR TITLE
AppLifecycleState.suspending is removed

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/cache_provider.dart
+++ b/packages/graphql_flutter/lib/src/widgets/cache_provider.dart
@@ -61,9 +61,6 @@ class _CacheProviderState extends State<CacheProvider>
         client.cache?.save();
         break;
 
-      case AppLifecycleState.suspending:
-        break;
-
       case AppLifecycleState.resumed:
         client.cache?.restore();
         break;


### PR DESCRIPTION
AppLifecycleState.suspending has been removed from the definition

Without this change, graphql-flutter does not work with flutter master 1.10.15-pre420 +


