### PR TITLE
Bump gql version, maybe fix nightly betas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       - checkout
       - run:
           name: Generate release tags
-          command: npx semantic-release@beta@16.0.0-beta.24
+          command: npx semantic-release@16.0.0-beta.24
   sync_with_beta:
     docker: *node_environment
     steps:

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path: ^1.6.2
   http_parser: ^3.1.3
   uuid_enhanced: ^3.0.2
-  gql: ^0.10.0
+  gql: ^0.11.1
   rxdart: ^0.22.0
   websocket: ^0.0.5
   quiver: ">=2.0.0 <3.0.0"


### PR DESCRIPTION
Might fix the nightly releases part of #461

Tried running circle ci locally, but there was a timeout during checkout. @HofmannZ do I need to set `GH_TOKEN` in the environment or something?