### PR TITLE
fix: use case else instead of detached or suspended

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/cache_provider.dart
+++ b/packages/graphql_flutter/lib/src/widgets/cache_provider.dart
@@ -61,11 +61,11 @@ class _CacheProviderState extends State<CacheProvider>
         client.cache?.save();
         break;
 
-      case AppLifecycleState.detached:
-        break;
-
       case AppLifecycleState.resumed:
         client.cache?.restore();
+        break;
+
+      default:
         break;
     }
   }


### PR DESCRIPTION
Since we are not using `AppLifecycleState.detached` or `AppLifecycleState.suspended` for anything specific other than just breaking, I propose we a `case` `default` to handle the scenarios. This way, we will maintain compatibility with older and newer versions of flutter.