### PR TITLE
fix: subscriptions reconnect

### DIFF
--- a/packages/graphql/test/socket_client_test.dart
+++ b/packages/graphql/test/socket_client_test.dart
@@ -2,11 +2,12 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:gql/language.dart';
+import 'package:graphql/client.dart';
 import 'package:graphql/src/link/operation.dart';
-import 'package:graphql/src/websocket/messages.dart';
-import 'package:test/test.dart';
 import 'package:graphql/src/socket_client.dart'
     show SocketClient, SocketConnectionState;
+import 'package:graphql/src/websocket/messages.dart';
+import 'package:test/test.dart';
 
 import 'helpers.dart';
 
@@ -42,6 +43,48 @@ void main() {
       final waitForConnection = true;
       final subscriptionDataStream =
           socketClient.subscribe(payload, waitForConnection);
+      await socketClient.connectionState
+          .where((state) => state == SocketConnectionState.CONNECTED)
+          .first;
+
+      // ignore: unawaited_futures
+      socketClient.socket.stream
+          .where((message) =>
+              message ==
+              r'{"type":"start","id":"01020304-0506-4708-890a-0b0c0d0e0f10","payload":{"operationName":null,"query":"subscription {\n  \n}","variables":{}}}')
+          .first
+          .then((_) {
+        socketClient.socket.add(jsonEncode({
+          'type': 'data',
+          'id': '01020304-0506-4708-890a-0b0c0d0e0f10',
+          'payload': {
+            'data': {'foo': 'bar'},
+            'errors': ['error and data can coexist']
+          }
+        }));
+      });
+
+      await expectLater(
+        subscriptionDataStream,
+        emits(
+          SubscriptionData(
+            '01020304-0506-4708-890a-0b0c0d0e0f10',
+            {'foo': 'bar'},
+            ['error and data can coexist'],
+          ),
+        ),
+      );
+    });
+    test('resubscribe', () async {
+      final payload = SubscriptionRequest(
+        Operation(documentNode: gql('subscription {}')),
+      );
+      final waitForConnection = true;
+      final subscriptionDataStream =
+          socketClient.subscribe(payload, waitForConnection);
+
+      socketClient.onConnectionLost();
+
       await socketClient.connectionState
           .where((state) => state == SocketConnectionState.CONNECTED)
           .first;


### PR DESCRIPTION
This PR resolves #407

#### Fixes / Enhancements

- updated `socket_client.dart` to keep map of `onListen` callbacks that are called again after reestablishing connection

p.s. I tried to reproduce it in test, but no luck (everything worked as expected). But manually it didn't work before this fix.