### PR TITLE
Support null value on getToken for authlink

### DIFF
--- a/packages/graphql/lib/src/link/auth/link_auth.dart
+++ b/packages/graphql/lib/src/link/auth/link_auth.dart
@@ -17,9 +17,11 @@ class AuthLink extends Link {
               try {
                 final String token = await getToken();
 
-                operation.setContext(<String, Map<String, String>>{
-                  'headers': <String, String>{'Authorization': token}
-                });
+                if (token != null) {
+                  operation.setContext(<String, Map<String, String>>{
+                    'headers': <String, String>{'Authorization': token}
+                  });
+                }
               } catch (error) {
                 controller.addError(error);
               }


### PR DESCRIPTION
#### Fixes / Enhancements

The `getToken` method on the `AuthLink` class expects you to return a valid token as a string, yet it does not take into account that this token may not yet be defined whenever the method is executed. As such, it will throw a `[Malformed Authorization header: Undefined location]` when the invalid token is added as an `Authorization` header to the operation's context.

The only necessary change seems to be the following. From:
```
operation.setContext(<String, Map<String, String>>{
  'headers': <String, String>{'Authorization': token}
});
```
To:
```
if (token != null) {
  operation.setContext(<String, Map<String, String>>{
    'headers': <String, String>{'Authorization': token}
  });
}
```
