### PR TITLE
Prevent observable discarding in MutationState.didChangeDependencies

### DIFF
--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -69,6 +69,8 @@ class Policies {
         overrides?.fetch ?? fetch,
         overrides?.error ?? error,
       );
+  operator ==(Object other) =>
+      other is Policies && fetch == other.fetch && error == other.error;
 }
 
 /// Base options.
@@ -308,6 +310,18 @@ class WatchQueryOptions extends QueryOptions {
     // compare variables last, because maps take more time
     return areDifferentVariables(a.variables, b.variables);
   }
+
+  WatchQueryOptions copy() => WatchQueryOptions(
+        documentNode: documentNode,
+        variables: variables,
+        fetchPolicy: fetchPolicy,
+        errorPolicy: errorPolicy,
+        optimisticResult: optimisticResult,
+        pollInterval: pollInterval,
+        fetchResults: fetchResults,
+        eagerlyFetchResults: eagerlyFetchResults,
+        context: context,
+      );
 }
 
 /// merge fetchMore result data with earlier result data

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   path: ^1.6.2
   http_parser: ^3.1.3
   uuid_enhanced: ^3.0.2
-  gql: ^0.11.1
+  gql: ^0.12.0
   rxdart: ^0.22.0
   websocket: ^0.0.5
   quiver: '>=2.0.0 <3.0.0'

--- a/packages/graphql_flutter/lib/src/widgets/mutation.dart
+++ b/packages/graphql_flutter/lib/src/widgets/mutation.dart
@@ -35,16 +35,33 @@ class MutationState extends State<Mutation> {
   GraphQLClient client;
   ObservableQuery observableQuery;
 
-  WatchQueryOptions get _options => WatchQueryOptions(
-        // ignore: deprecated_member_use
-        document: widget.options.document,
-        documentNode: widget.options.documentNode,
-        variables: widget.options.variables,
-        fetchPolicy: widget.options.fetchPolicy,
-        errorPolicy: widget.options.errorPolicy,
-        fetchResults: false,
-        context: widget.options.context,
-      );
+  WatchQueryOptions __cachedOptions;
+
+  WatchQueryOptions get _providedOptions {
+    final _options = WatchQueryOptions(
+      // ignore: deprecated_member_use
+      document: widget.options.document,
+      documentNode: widget.options.documentNode,
+      variables: widget.options.variables,
+      fetchPolicy: widget.options.fetchPolicy,
+      errorPolicy: widget.options.errorPolicy,
+      fetchResults: false,
+      context: widget.options.context,
+    );
+    __cachedOptions ??= _options;
+    return _options;
+  }
+
+  /// sets new options, returning true if they didn't equal the old
+  bool _setNewOptions() {
+    final _cached = __cachedOptions;
+    final _new = _providedOptions;
+    if (_cached == null || !_new.areEqualTo(_cached)) {
+      __cachedOptions = _new;
+      return true;
+    }
+    return false;
+  }
 
   // TODO is it possible to extract shared logic into mixin
   void _initQuery() {
@@ -52,7 +69,7 @@ class MutationState extends State<Mutation> {
     assert(client != null);
 
     observableQuery?.close();
-    observableQuery = client.watchQuery(_options);
+    observableQuery = client.watchQuery(_providedOptions.copy());
   }
 
   @override
@@ -66,7 +83,7 @@ class MutationState extends State<Mutation> {
     super.didUpdateWidget(oldWidget);
 
     // TODO @micimize - investigate why/if this was causing issues
-    if (!observableQuery.options.areEqualTo(_options)) {
+    if (_setNewOptions()) {
       _initQuery();
     }
   }


### PR DESCRIPTION
Closes #388

We set attributes on `options` when `runMutation` is called, and it always resulted in query re initialization.
 
So, to avoid constant not-equals comparison, we cache and copy options in `MutationState`

#### No Breaking or API Changes

#### Fixes / Enhancements
Required implementing
* `Policies ==`
* `WatchQueryOptions.copy`
* and `Mutation.__cachedOptions`
 .