### PR TITLE
fix(packaging): update rxdart and sdk min versions

### DIFF
--- a/packages/graphql/example/pubspec.yaml
+++ b/packages/graphql/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for using GraphQL Dart
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   args: 

--- a/packages/graphql/lib/legacy_socket_api/legacy_socket_client.dart
+++ b/packages/graphql/lib/legacy_socket_api/legacy_socket_client.dart
@@ -282,7 +282,7 @@ class SocketClient {
         config.queryAndMutationTimeout != null;
 
     response.onListen = () {
-      final Observable<SocketConnectionState>
+      final Stream<SocketConnectionState>
           waitForConnectedStateWithoutTimeout = _connectionStateController
               .startWith(
                   waitForConnection ? null : SocketConnectionState.CONNECTED)
@@ -290,7 +290,7 @@ class SocketClient {
                   state == SocketConnectionState.CONNECTED)
               .take(1);
 
-      final Observable<SocketConnectionState> waitForConnectedState = addTimeout
+      final Stream<SocketConnectionState> waitForConnectedState = addTimeout
           ? waitForConnectedStateWithoutTimeout.timeout(
               config.queryAndMutationTimeout,
               onTimeout: (EventSink<SocketConnectionState> event) {

--- a/packages/graphql/lib/src/socket_client.dart
+++ b/packages/graphql/lib/src/socket_client.dart
@@ -259,7 +259,7 @@ class SocketClient {
         config.queryAndMutationTimeout != null;
 
     final onListen = () {
-      final Observable<SocketConnectionState>
+      final Stream<SocketConnectionState>
           waitForConnectedStateWithoutTimeout = _connectionStateController
               .startWith(
                   waitForConnection ? null : SocketConnectionState.CONNECTED)
@@ -267,7 +267,7 @@ class SocketClient {
                   state == SocketConnectionState.CONNECTED)
               .take(1);
 
-      final Observable<SocketConnectionState> waitForConnectedState = addTimeout
+      final Stream<SocketConnectionState> waitForConnectedState = addTimeout
           ? waitForConnectedStateWithoutTimeout.timeout(
               config.queryAndMutationTimeout,
               onTimeout: (EventSink<SocketConnectionState> event) {

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   http_parser: ^3.1.3
   uuid_enhanced: ^3.0.2
   gql: ^0.12.0
-  rxdart: ^0.22.0
+  rxdart: ^0.23.1
   websocket: ^0.0.5
   quiver: '>=2.0.0 <3.0.0'
 dev_dependencies:
@@ -25,4 +25,4 @@ dev_dependencies:
   test: ^1.5.3
   test_coverage: ^0.3.0+1
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'

--- a/packages/graphql_flutter/example/pubspec.yaml
+++ b/packages/graphql_flutter/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^0.1.2
-  rxdart: ^0.22.0
+  rxdart: ^0.23.1
   connectivity: ^0.4.4
   graphql_flutter:
     path: ..

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   meta: ^1.1.6
   path: ^1.6.2
   path_provider: ^1.1.0
-  rxdart: ^0.22.0
+  rxdart: ^0.23.1
   connectivity: ^0.4.4
 dev_dependencies:
   pedantic: ^1.8.0+1
@@ -23,4 +23,4 @@ dev_dependencies:
     sdk: flutter
   test: ^1.5.3
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'


### PR DESCRIPTION
Support new rxdart version

### Breaking changes
- min rxdart version is 0.23.1
- min sdk version is 2.6.0 (since rxdart 0.23.* require extension methods)

#### Fixes / Enhancements

- Closes #497



I wasn't able to find how do you manage iterative updates, so these commit affects both graphql and flutter_graphql packages. This causing a problem: flutter_graphql dependency on graphql couldn't properly updated in this commit.
Can you please guide me how do you handle this type of issues in your repo?
