### PR TITLE
Allow SocketClientConfig to have a Future initPayload

### DIFF
--- a/packages/graphql/lib/src/socket_client.dart
+++ b/packages/graphql/lib/src/socket_client.dart
@@ -41,9 +41,12 @@ class SocketClientConfig {
 
   /// The initial payload that will be sent to the server upon connection.
   /// Can be null, but must be a valid json structure if provided.
-  final dynamic initPayload;
+  final FutureOr<dynamic> initPayload;
 
-  InitOperation get initOperation => InitOperation(initPayload);
+  Future<InitOperation> get initOperation async {
+    dynamic payload = await initPayload;
+    return InitOperation(payload);
+  }
 }
 
 enum SocketConnectionState { NOT_CONNECTED, CONNECTING, CONNECTED }
@@ -105,7 +108,7 @@ class SocketClient {
       );
       _connectionStateController.value = SocketConnectionState.CONNECTED;
       print('Connected to websocket.');
-      _write(config.initOperation);
+      _write(await config.initOperation);
 
       _messageStream =
           _socket.stream.map<GraphQLSocketMessage>(_parseSocketMessage);

--- a/packages/graphql/test/socket_client_test.dart
+++ b/packages/graphql/test/socket_client_test.dart
@@ -37,50 +37,40 @@ void main() {
       );
     });
     test('connection with non future initPayload', () async {
-      const initPayload = {
-        'token': 'mytoken'
-      };
+      const initPayload = {'token': 'mytoken'};
 
-      socketClient = SocketClient(
-        'ws://echo.websocket.org',
-        protocols: null,
-        randomBytesForUuid: Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-        config: SocketClientConfig(initPayload: initPayload)
-      );
+      socketClient = SocketClient('ws://echo.websocket.org',
+          protocols: null,
+          randomBytesForUuid: Uint8List.fromList(
+              [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+          config: SocketClientConfig(initPayload: initPayload));
 
       await socketClient.connectionState
-        .where((state) => state == SocketConnectionState.CONNECTED)
-        .first;
+          .where((state) => state == SocketConnectionState.CONNECTED)
+          .first;
 
-      await expectLater(
-        socketClient.socket.stream.map((s) {
-          return jsonDecode(s)['payload'];
-        }),
-        emits(initPayload)
-      );
+      await expectLater(socketClient.socket.stream.map((s) {
+        return jsonDecode(s)['payload'];
+      }), emits(initPayload));
     });
     test('connection with future initPayload', () async {
-      const initPayload = {
-        'token': 'mytoken'
-      };
+      const initPayload = {'token': 'mytoken'};
 
-      socketClient = SocketClient(
-        'ws://echo.websocket.org',
-        protocols: null,
-        randomBytesForUuid: Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
-        config: SocketClientConfig(initPayload: Future.delayed(Duration(seconds: 3), () => initPayload))
-      );
+      socketClient = SocketClient('ws://echo.websocket.org',
+          protocols: null,
+          randomBytesForUuid: Uint8List.fromList(
+              [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+          config: SocketClientConfig(
+              initPayload:
+                  Future.delayed(Duration(seconds: 3), () => initPayload)));
 
       await socketClient.connectionState
-        .where((state) => state == SocketConnectionState.CONNECTED)
-        .first;
+          .where((state) => state == SocketConnectionState.CONNECTED)
+          .first;
 
-      await expectLater(
-        socketClient.socket.stream.map((s) {
-          return jsonDecode(s)['payload'];
-        }),
-        emits(initPayload)
-      );
+      await expectLater(socketClient.socket.stream.map((s) {
+        return jsonDecode(s)['payload'];
+      }), emits(initPayload));
     });
     test('subscription data', () async {
       final payload = SubscriptionRequest(

--- a/packages/graphql/test/socket_client_test.dart
+++ b/packages/graphql/test/socket_client_test.dart
@@ -36,6 +36,52 @@ void main() {
         ),
       );
     });
+    test('connection with non future initPayload', () async {
+      const initPayload = {
+        'token': 'mytoken'
+      };
+
+      socketClient = SocketClient(
+        'ws://echo.websocket.org',
+        protocols: null,
+        randomBytesForUuid: Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+        config: SocketClientConfig(initPayload: initPayload)
+      );
+
+      await socketClient.connectionState
+        .where((state) => state == SocketConnectionState.CONNECTED)
+        .first;
+
+      await expectLater(
+        socketClient.socket.stream.map((s) {
+          return jsonDecode(s)['payload'];
+        }),
+        emits(initPayload)
+      );
+    });
+    test('connection with future initPayload', () async {
+      const initPayload = {
+        'token': 'mytoken'
+      };
+
+      socketClient = SocketClient(
+        'ws://echo.websocket.org',
+        protocols: null,
+        randomBytesForUuid: Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+        config: SocketClientConfig(initPayload: Future.delayed(Duration(seconds: 3), () => initPayload))
+      );
+
+      await socketClient.connectionState
+        .where((state) => state == SocketConnectionState.CONNECTED)
+        .first;
+
+      await expectLater(
+        socketClient.socket.stream.map((s) {
+          return jsonDecode(s)['payload'];
+        }),
+        emits(initPayload)
+      );
+    });
     test('subscription data', () async {
       final payload = SubscriptionRequest(
         Operation(documentNode: parseString('subscription {}')),


### PR DESCRIPTION
Describe the purpose of the pull request.

### Breaking changes

- none

#### Fixes / Enhancements

- Added the ability to use a `Future` for the `initPayload` of a `SocketClient` in the same way the AuthLink.getToken is. This allows a user to provide their bearer token more easily.

#### Docs

```dart
SocketClientConfig(
  initPayload: () async {
    FirebaseUser user = await FirebaseAuth.instance.currentUser();
    IdTokenResult idTokenResult = await user.getIdToken();

    return {
      "headers": {"Authorization": 'Bearer ${idToken.token}'},
    };
  },
)
```