### PR TITLE
Allow SocketClientConfig to have a Future initPayload

### DIFF
--- a/packages/graphql/lib/src/socket_client.dart
+++ b/packages/graphql/lib/src/socket_client.dart
@@ -41,9 +41,12 @@ class SocketClientConfig {
 
   /// The initial payload that will be sent to the server upon connection.
   /// Can be null, but must be a valid json structure if provided.
-  final dynamic initPayload;
+  final FutureOr<dynamic> initPayload;
 
-  InitOperation get initOperation => InitOperation(initPayload);
+  Future<InitOperation> get initOperation async {
+    dynamic payload = await initPayload;
+    return InitOperation(payload);
+  }
 }
 
 enum SocketConnectionState { NOT_CONNECTED, CONNECTING, CONNECTED }
@@ -105,7 +108,7 @@ class SocketClient {
       );
       _connectionStateController.value = SocketConnectionState.CONNECTED;
       print('Connected to websocket.');
-      _write(config.initOperation);
+      _write(await config.initOperation);
 
       _messageStream =
           _socket.stream.map<GraphQLSocketMessage>(_parseSocketMessage);


### PR DESCRIPTION
#### Breaking changes

- none

#### Fixes / Enhancements

- Added the ability to use a `Future` for the `initPayload` of a `SocketClient` in the same way the AuthLink.getToken is. This allows a user to provide their bearer token more easily.

#### Docs

```dart
SocketClientConfig(
  initPayload: () async {
    FirebaseUser user = await FirebaseAuth.instance.currentUser();
    IdTokenResult idTokenResult = await user.getIdToken();

    return {
      "headers": {"Authorization": 'Bearer ${idToken.token}'},
    };
  },
)
```