### PR TITLE
Fix calling host getter on address which can be null

### DIFF
--- a/packages/graphql/lib/src/exceptions/io_network_exception.dart
+++ b/packages/graphql/lib/src/exceptions/io_network_exception.dart
@@ -11,7 +11,7 @@ stub.NetworkException translateNetworkFailure(dynamic failure) {
       message: failure.message,
       uri: Uri(
         scheme: 'http',
-        host: failure.address.host,
+        host: failure.address?.host,
         port: failure.port,
       ),
     );


### PR DESCRIPTION
Fixes calling the `host` getter on an `address` that is `null`. This can occur when handling an exception because the client has no connectivity:

<img width="1003" alt="Screenshot 2019-12-31 at 01 05 01" src="https://user-images.githubusercontent.com/5159563/71605544-e31b5080-2b69-11ea-8c91-4c3e63cee534.png">