### PR TITLE
Fixed instance variable declaration and usage in InMemory

### DIFF
--- a/packages/graphql/lib/src/cache/in_memory_html.dart
+++ b/packages/graphql/lib/src/cache/in_memory_html.dart
@@ -13,7 +13,7 @@ class InMemoryCache implements Cache {
   InMemoryCache({
     this.storagePrefix = '',
   }) {
-    masterKey = storagePrefix.toString() ?? '' + '_graphql_cache';
+    masterKey = storagePrefix.toString() ?? '_graphql_cache';
   }
 
   final FutureOr<String> storagePrefix;

--- a/packages/graphql/lib/src/cache/in_memory_html.dart
+++ b/packages/graphql/lib/src/cache/in_memory_html.dart
@@ -13,7 +13,7 @@ class InMemoryCache implements Cache {
   InMemoryCache({
     this.storagePrefix = '',
   }) {
-    masterKey = storagePrefix ?? '' + '_graphql_cache';
+    masterKey = storagePrefix.toString() ?? '' + '_graphql_cache';
   }
 
   final FutureOr<String> storagePrefix;

--- a/packages/graphql/lib/src/cache/in_memory_html.dart
+++ b/packages/graphql/lib/src/cache/in_memory_html.dart
@@ -16,7 +16,7 @@ class InMemoryCache implements Cache {
     masterKey = storagePrefix ?? '' + '_graphql_cache';
   }
 
-  final String storagePrefix;
+  final FutureOr<String> storagePrefix;
   String masterKey;
 
   @protected


### PR DESCRIPTION
`storagePrefix` was declared `String` in `in_memory_html.dart`, as opposed to `FutureOr<String>` in `in_memory_io.dart`. This causes an error (described in issue #520).

### Breaking changes

- No breaking changes

#### Fixes / Enhancements

- Fixed declaration and usage as described.
