### PR TITLE
fix(client): fix(client): translateNetworkFailure fails with NPE when no route to host

### DIFF
--- a/packages/graphql/lib/src/exceptions/io_network_exception.dart
+++ b/packages/graphql/lib/src/exceptions/io_network_exception.dart
@@ -11,7 +11,7 @@ stub.NetworkException translateNetworkFailure(dynamic failure) {
       message: failure.message,
       uri: Uri(
         scheme: 'http',
-        host: failure.address.host,
+        host: failure.address?.host,
         port: failure.port,
       ),
     );


### PR DESCRIPTION
This one-liner change prevents a null pointer exception when host name resolution has failed. This can happen, e.g. when the phone has been left into flight mode, or when the network access has failed.

This bug was particularly nasty, as it prevented the normal error handling mechanism to operate (e.g. no OperationException would not be created).

### Breaking changes

- No breaking changes

#### Fixes / Enhancements

- Fixed translateNetworkFailure() method to not throw an error because of accessing null address at "failure.address.host"

#### Docs

- None added/updated