### PR TITLE
fix(flutter): widgets make unnecessary requests when dependencies change

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/mutation.dart
+++ b/packages/graphql_flutter/lib/src/widgets/mutation.dart
@@ -65,9 +65,6 @@ class MutationState extends State<Mutation> {
 
   // TODO is it possible to extract shared logic into mixin
   void _initQuery() {
-    client = GraphQLProvider.of(context).value;
-    assert(client != null);
-
     observableQuery?.close();
     observableQuery = client.watchQuery(_providedOptions.copy());
   }
@@ -75,7 +72,12 @@ class MutationState extends State<Mutation> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _initQuery();
+    final GraphQLClient client = GraphQLProvider.of(context).value;
+    assert(client != null);
+    if (client != this.client) {
+      this.client = client;
+      _initQuery();
+    }
   }
 
   @override

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -34,7 +34,7 @@ class Query extends StatefulWidget {
 
 class QueryState extends State<Query> {
   ObservableQuery observableQuery;
-
+  GraphQLClient _client;
   WatchQueryOptions get _options {
     final QueryOptions options = widget.options;
 
@@ -53,17 +53,19 @@ class QueryState extends State<Query> {
   }
 
   void _initQuery() {
-    final GraphQLClient client = GraphQLProvider.of(context).value;
-    assert(client != null);
-
     observableQuery?.close();
-    observableQuery = client.watchQuery(_options);
+    observableQuery = _client.watchQuery(_options);
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _initQuery();
+    final GraphQLClient client = GraphQLProvider.of(context).value;
+    assert(client != null);
+    if (client != _client) {
+      _client = client;
+      _initQuery();
+    }
   }
 
   @override

--- a/packages/graphql_flutter/lib/src/widgets/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/subscription.dart
@@ -43,20 +43,20 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
   T _data;
   dynamic _error;
   StreamSubscription<FetchResult> _subscription;
+  GraphQLClient _client;
 
   ConnectivityResult _currentConnectivityResult;
   StreamSubscription<ConnectivityResult> _networkSubscription;
 
   void _initSubscription() {
-    final GraphQLClient client = GraphQLProvider.of(context).value;
-    assert(client != null);
+    assert(_client != null);
     final Operation operation = Operation(
       documentNode: parseString(widget.query),
       variables: widget.variables,
       operationName: widget.operationName,
     );
 
-    final Stream<FetchResult> stream = client.subscribe(operation);
+    final Stream<FetchResult> stream = _client.subscribe(operation);
 
     if (_subscription == null) {
       // Set the initial value for the first time.
@@ -88,7 +88,12 @@ class _SubscriptionState<T> extends State<Subscription<T>> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _initSubscription();
+    final GraphQLClient client = GraphQLProvider.of(context).value;
+    assert(client != null);
+    if (client != _client) {
+      _client = client;
+      _initSubscription();
+    }
   }
 
   @override


### PR DESCRIPTION
Similar to #352 but it looks like it's stalled. I think this PR is more complete.

Widgets can get its `didChangeDependencies` method called multiple times even when no real changes have happened to its own dependencies. As a result, our query and mutation widgets may perform many unnecessary network fetches. In my scenario I get hundreds of unnecessary requests.

See [reddit discussion](https://www.reddit.com/r/FlutterDev/comments/c1911m/how_do_your_handle_fetching_data_inside/) and https://github.com/flutter/flutter/issues/39872 for more info.

The solution is to store the `client` in the widget state and check if it really changed before reinitializing the query.
