### PR TITLE
fix future initPayload for subscription

### DIFF
--- a/packages/graphql/lib/legacy_socket_api/legacy_socket_client.dart
+++ b/packages/graphql/lib/legacy_socket_api/legacy_socket_client.dart
@@ -282,8 +282,8 @@ class SocketClient {
         config.queryAndMutationTimeout != null;
 
     response.onListen = () {
-      final Stream<SocketConnectionState>
-          waitForConnectedStateWithoutTimeout = _connectionStateController
+      final Stream<SocketConnectionState> waitForConnectedStateWithoutTimeout =
+          _connectionStateController
               .startWith(
                   waitForConnection ? null : SocketConnectionState.CONNECTED)
               .where((SocketConnectionState state) =>

--- a/packages/graphql/test/socket_client_test.dart
+++ b/packages/graphql/test/socket_client_test.dart
@@ -126,7 +126,7 @@ void main() {
     setUp(overridePrint((log) {
       socketClient = SocketClient(
         'ws://echo.websocket.org',
-        config: SocketClientConfig(initPayload: initPayload),
+        config: SocketClientConfig(initPayload: () => initPayload),
       );
     }));
 
@@ -153,7 +153,10 @@ void main() {
       socketClient = SocketClient(
         'ws://echo.websocket.org',
         config: SocketClientConfig(
-          initPayload: Future.delayed(Duration(seconds: 3), () => initPayload),
+          initPayload: () async {
+            await Future.delayed(Duration(seconds: 3));
+            return initPayload;
+          },
         ),
       );
     }));


### PR DESCRIPTION
#### Breaking changes
Previously: 
```dart
const initPayload = {'token': 'myToken'};
SocketClientConfig(initPayload: initPayload)
```
Now: 
```dart
// synchronous
const initPayload = {'token': 'myToken'};
SocketClientConfig(initPayload: () => initPayload)

// asynchronous
SocketClientConfig(
  initPayload: () async {
    FirebaseUser user = await FirebaseAuth.instance.currentUser();
    IdTokenResult idTokenResult = await user.getIdToken();

    return {
      "headers": {"Authorization": 'Bearer ${idToken.token}'},
    };
  },
)
```

#### Fixes / Enhancements
This fixes my previous PR to use Futures for subscription initPayload. Previously, initPayload took in a `FutureOr<dynamic>`, now it takes in a `FutureOr<dynamic> Function`

