### PR TITLE
Thow a ClientException on non-json responses

### DIFF
--- a/packages/graphql/lib/src/link/http/link_http.dart
+++ b/packages/graphql/lib/src/link/http/link_http.dart
@@ -318,8 +318,12 @@ Future<FetchResult> _parseResponse(StreamedResponse response) async {
   final Uint8List responseByte = await response.stream.toBytes();
   final String decodedBody = encoding.decode(responseByte);
 
-  final Map<String, dynamic> jsonResponse =
-      json.decode(decodedBody) as Map<String, dynamic>;
+  Map<String, dynamic> jsonResponse;
+  try {
+      jsonResponse=  json.decode(decodedBody) as Map<String, dynamic>;
+  }catch(e){
+    throw ClientException('Invalid response body: $decodedBody');
+  }
   final FetchResult fetchResult = FetchResult();
 
   if (jsonResponse['errors'] != null) {

--- a/packages/graphql/test/link/http/link_http_test.dart
+++ b/packages/graphql/test/link/http/link_http_test.dart
@@ -453,12 +453,12 @@ void main() {
 
       expect(
         exception,
-        const TypeMatcher<UnhandledFailureWrapper>(),
+        const TypeMatcher<ClientException>(),
       );
 
       expect(
-        (exception as UnhandledFailureWrapper).failure,
-        const TypeMatcher<FormatException>(),
+        (exception as ClientException).message,
+        "Invalid response body: ",
       );
     });
 


### PR DESCRIPTION
Implements the proposed fix in #552. Fixes #552.

### Breaking changes

- Broke: In non-JSON responses, a ClientException gets thrown instead of an UnhandledFailureWrapper
 because: In my opinion, this is more consistent with other malformed responses and the root cause of the exception is more clear to the user

#### Fixes / Enhancements


- Updated test that verifies the behavior on non-json responses

