### PR TITLE
Add documentation about AppSync support

### DIFF
--- a/packages/graphql_flutter/README.md
+++ b/packages/graphql_flutter/README.md
@@ -106,6 +106,32 @@ In order to use the client, you `Query` and `Mutation` widgets to be wrapped wit
   ...
 ```
 
+### AWS AppSync Support
+
+#### Cognito Pools
+
+To use with an AppSync GraphQL API that is authorized with AWS Cognito User Pools, simply pass the JWT token for your Cognito user session in to the `AuthLink`:
+
+```dart
+// Where `session` is a CognitorUserSession
+// from amazon_cognito_identity_dart_2
+final token = session.getAccessToken().getJwtToken();
+
+final AuthLink authLink = AuthLink(
+  getToken: () => token,
+);
+```
+
+See more: [Issue #209](https://github.com/zino-app/graphql-flutter/issues/209)
+
+#### Other Authorization Types
+
+API key, IAM, and Federated provider authorization could be accomplished through custom links, but it is not known to be supported. Anyone wanting to implement this can reference AWS' JS SDK `AuthLink` implementation.
+
+Making a custom link: [Comment on Issue 173](https://github.com/zino-app/graphql-flutter/issues/173#issuecomment-464435942)
+AWS JS SDK `auth-link.ts`: [aws-mobile-appsync-sdk-js:auth-link.ts](https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/master/packages/aws-appsync-auth-link/src/auth-link.ts)
+
+
 ### Offline Cache
 
 The in-memory cache can automatically be saved to and restored from offline storage. Setting it up is as easy as wrapping your app with the `CacheProvider` widget.

--- a/packages/graphql_flutter/README.md
+++ b/packages/graphql_flutter/README.md
@@ -128,8 +128,8 @@ See more: [Issue #209](https://github.com/zino-app/graphql-flutter/issues/209)
 
 API key, IAM, and Federated provider authorization could be accomplished through custom links, but it is not known to be supported. Anyone wanting to implement this can reference AWS' JS SDK `AuthLink` implementation.
 
-Making a custom link: [Comment on Issue 173](https://github.com/zino-app/graphql-flutter/issues/173#issuecomment-464435942)
-AWS JS SDK `auth-link.ts`: [aws-mobile-appsync-sdk-js:auth-link.ts](https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/master/packages/aws-appsync-auth-link/src/auth-link.ts)
+- Making a custom link: [Comment on Issue 173](https://github.com/zino-app/graphql-flutter/issues/173#issuecomment-464435942)
+- AWS JS SDK `auth-link.ts`: [aws-mobile-appsync-sdk-js:auth-link.ts](https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/master/packages/aws-appsync-auth-link/src/auth-link.ts)
 
 
 ### Offline Cache


### PR DESCRIPTION
add a section to the readme to track support for AWS AppSync and outline how it can be used with Cognito.

related to #209 

#### Docs

- Added details on how to use it with Cognito pools and instructions for a custom link for the other methods.

**Note:** I think the other authorization methods would be dead easy to implement. The only thing stopping me from doing it is that I don't have time to spin up several AppSync projects and test them against a Flutter app. If anyone feels like testing, I'll spin my project back up https://github.com/HoodHub/aws_appsync_auth_link_dart and create an `AwsAuthLink` for you to test. However, if no one feels like doing the testing, I think this add to the documentation is necessary for now. I spent 6 hours working on my own link for authorizing against Cognito pools until I figured out I could just pass in the JWT token. If someone tests and we get my project up, this documentation could be updated to say that AppSync is fully supported through that project.
