### PR TITLE
fix(flutter): Query.didUpdateWidget and policy overrides

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,9 +7,15 @@ flags:
         - packages/graphql/
 comment:
   require_changes: true # Only post a comment if coverage changes.
+
 coverage:
   status:
     project:
       default:
         threshold: 1% # Allow coverage to drop by up to 1% in a PR before marking it failed
     patch: off
+
+# don't factor tests into coverage scores
+ignore:
+  - packages/graphql_flutter/test
+  - packages/graphql/test

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -72,7 +72,13 @@ class QueryState extends State<Query> {
   void didUpdateWidget(Query oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (!observableQuery.options.areEqualTo(_options)) {
+    final GraphQLClient client = GraphQLProvider.of(context).value;
+
+    final optionsWithOverrides = _options;
+    optionsWithOverrides.policies = client.defaultPolicies.watchQuery
+      .withOverrides(optionsWithOverrides.policies);
+
+    if (!observableQuery.options.areEqualTo(optionsWithOverrides)) {
       _initQuery();
     }
   }

--- a/packages/graphql_flutter/test/widgets/query_test.dart
+++ b/packages/graphql_flutter/test/widgets/query_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:graphql_flutter/src/widgets/query.dart';
+import 'package:http/http.dart';
+import 'package:mockito/mockito.dart';
+
+class MockHttpClient extends Mock implements Client {}
+
+final query = gql("""
+  query Foo {
+    foo
+  }
+""");
+
+class Page extends StatefulWidget {
+  final Map<String, dynamic> variables;
+  final FetchPolicy fetchPolicy;
+  final ErrorPolicy errorPolicy;
+
+  Page({
+    Key key,
+    this.variables,
+    this.fetchPolicy,
+    this.errorPolicy,
+  }): super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => PageState();
+}
+
+class PageState extends State<Page> {
+  Map<String, dynamic> variables;
+  FetchPolicy fetchPolicy;
+  ErrorPolicy errorPolicy;
+
+  @override
+  void initState() {
+    super.initState();
+    variables = widget.variables;
+    fetchPolicy = widget.fetchPolicy;
+    errorPolicy = widget.errorPolicy;
+  }
+
+  setVariables(Map<String, dynamic> newVariables) {
+    setState(() {
+      variables = newVariables;
+    });
+  }
+
+  setFetchPolicy(FetchPolicy newFetchPolicy) {
+    setState(() {
+      fetchPolicy = newFetchPolicy;
+    });
+  }
+
+  setErrorPolicy(ErrorPolicy newErrorPolicy) {
+    setState(() {
+      errorPolicy = newErrorPolicy;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Query(
+      options: QueryOptions(
+        documentNode: query,
+        variables: variables,
+        fetchPolicy: fetchPolicy,
+        errorPolicy: errorPolicy,
+      ),
+      builder: (QueryResult result, {
+        Refetch refetch,
+        FetchMore fetchMore
+      }) => Container(),
+    );
+  }
+}
+
+void main() {
+  group('Query', () {
+    MockHttpClient mockHttpClient;
+    HttpLink httpLink;
+    ValueNotifier<GraphQLClient> client;
+
+    setUp(() async {
+      mockHttpClient = MockHttpClient();
+      httpLink = HttpLink(
+        uri: 'https://unused/graphql',
+        httpClient: mockHttpClient,
+      );
+      client = ValueNotifier(
+        GraphQLClient(
+          cache: InMemoryCache(storagePrefix: 'test'),
+          link: httpLink,
+        ),
+      );
+    });
+
+    testWidgets('does not issue network request on same options',
+        (WidgetTester tester) async {
+      final page = Page(
+        variables: {
+          'foo': 1,
+        },
+        fetchPolicy: FetchPolicy.networkOnly,
+        errorPolicy: ErrorPolicy.ignore,
+      );
+
+      await tester.pumpWidget(GraphQLProvider(
+        client: client,
+        child: page,
+      ));
+
+      verify(mockHttpClient.send(any)).called(1);
+
+      tester.state<PageState>(find.byWidget(page))
+        ..setVariables({'foo': 1})
+        ..setFetchPolicy(FetchPolicy.networkOnly)
+        ..setErrorPolicy(ErrorPolicy.ignore);
+      await tester.pump();
+      verifyNoMoreInteractions(mockHttpClient);
+    });
+
+    testWidgets('does not issue network request when policies stays null',
+        (WidgetTester tester) async {
+      final page = Page(
+        variables: {
+          'foo': 1,
+        },
+      );
+
+      await tester.pumpWidget(GraphQLProvider(
+        client: client,
+        child: page,
+      ));
+
+      verify(mockHttpClient.send(any)).called(1);
+
+      tester.state<PageState>(find.byWidget(page))
+        ..setFetchPolicy(null)
+        ..setErrorPolicy(null);
+      await tester.pump();
+      verifyNoMoreInteractions(mockHttpClient);
+    });
+
+    testWidgets('issues a new network request when variables change',
+        (WidgetTester tester) async {
+      final page = Page(
+        variables: {
+          'foo': 1,
+        },
+      );
+
+      await tester.pumpWidget(GraphQLProvider(
+        client: client,
+        child: page,
+      ));
+
+      verify(mockHttpClient.send(any)).called(1);
+
+      tester.state<PageState>(find.byWidget(page))
+        .setVariables({'foo': 2});
+      await tester.pump();
+      verify(mockHttpClient.send(any)).called(1);
+    });
+
+    testWidgets('issues a new network request when fetch policy changes',
+        (WidgetTester tester) async {
+      final page = Page(
+        fetchPolicy: FetchPolicy.networkOnly,
+      );
+
+      await tester.pumpWidget(GraphQLProvider(
+        client: client,
+        child: page,
+      ));
+
+      verify(mockHttpClient.send(any)).called(1);
+
+      tester.state<PageState>(find.byWidget(page))
+        .setFetchPolicy(FetchPolicy.cacheFirst);
+      await tester.pump();
+      verify(mockHttpClient.send(any)).called(1);
+    });
+
+    testWidgets('issues a new network request when error policy changes',
+        (WidgetTester tester) async {
+      final page = Page(
+        errorPolicy: ErrorPolicy.all,
+      );
+
+      await tester.pumpWidget(GraphQLProvider(
+        client: client,
+        child: page,
+      ));
+
+      verify(mockHttpClient.send(any)).called(1);
+
+      tester.state<PageState>(find.byWidget(page))
+        .setErrorPolicy(ErrorPolicy.none);
+      await tester.pump();
+      verify(mockHttpClient.send(any)).called(1);
+    });
+
+    testWidgets('does not issues new network request when policies are effectively unchanged',
+        (WidgetTester tester) async {
+      final page = Page(
+        fetchPolicy: FetchPolicy.cacheAndNetwork,
+        errorPolicy: null,
+      );
+
+      await tester.pumpWidget(GraphQLProvider(
+        client: client,
+        child: page,
+      ));
+
+      verify(mockHttpClient.send(any)).called(1);
+
+      tester.state<PageState>(find.byWidget(page))
+        ..setFetchPolicy(null)
+        ..setErrorPolicy(ErrorPolicy.none);
+      await tester.pump();
+      verifyNoMoreInteractions(mockHttpClient);
+    });
+  });
+}


### PR DESCRIPTION
The bug was first reported in https://github.com/zino-app/graphql-flutter/issues/575#issuecomment-612827953, quoted as follows:

> We found another bug that causes queries to be run multiple times in certain cases despite the fix in #533. That happens when:
> 1. Query is rebuilt by the parent. In the context of Navigator push/pop, this happens when Query has a stateful ancestor since every state seems to be built again when push/pop. See https://github.com/flutter/flutter/issues/11655
> 2. QueryState.didUpdateWidget is called, and it tries to compare the old and new options to decide whether to rebuild ObservableQuery.
> 3. Here is the actual bug: WatchQueryOptions.areEqualTo() does not consider default policy overrides. So when a query does not have fetch or error policies set, the equality check will fail, causing ObservableQuery to be rebuilt.

#### Fixes / Enhancements

- Fixed query options check in QueryState.didUpdateWidget by taking default policies into consideration.

Note:
- Added some test cases.
- Looks like the Mutation widget does not have the same problem since its implementation stores the previous query options BEFORE defaults overrides for comparison purpose. Nonetheless, I think comparing query options AFTER default overrides would be slightly better.
