### PR TITLE
update to include initial state

### DIFF
--- a/examples/flutter_bloc/lib/extended_bloc.dart
+++ b/examples/flutter_bloc/lib/extended_bloc.dart
@@ -54,7 +54,7 @@ class _ExtendedBlocState extends State<ExtendedBloc> {
                 builder: (_, state) {
                   Widget child = Container();
 
-                  if (state is GraphqlLoading) {
+                  if (state is GraphqlLoadingState) {
                     child = Center(child: CircularProgressIndicator());
                   }
 

--- a/examples/flutter_bloc/lib/extended_bloc/graphql/event.dart
+++ b/examples/flutter_bloc/lib/extended_bloc/graphql/event.dart
@@ -10,6 +10,12 @@ class GraphqlErrorEvent<T> extends GraphqlEvent<T> {
   GraphqlErrorEvent({@required this.error, @required this.result});
 }
 
+class GraphqlLoadingEvent<T> extends GraphqlEvent<T> {
+  final QueryResult result;
+
+  GraphqlLoadingEvent({@required this.result});
+}
+
 class GraphqlLoadedEvent<T> extends GraphqlEvent<T> {
   final T data;
   final QueryResult result;

--- a/examples/flutter_bloc/lib/extended_bloc/graphql/state.dart
+++ b/examples/flutter_bloc/lib/extended_bloc/graphql/state.dart
@@ -7,7 +7,13 @@ abstract class GraphqlState<T> {
   const GraphqlState({@required this.data});
 }
 
-class GraphqlLoading<T> extends GraphqlState<T> {}
+class GraphqlInitialState<T> extends GraphqlState<T> {}
+
+class GraphqlLoadingState<T> extends GraphqlState<T> {
+  final QueryResult result;
+
+  GraphqlLoadingState({@required this.result}) : super(data: null);
+}
 
 class GraphqlErrorState<T> extends GraphqlState<T> {
   final OperationException error;

--- a/examples/flutter_bloc/lib/extended_bloc/repositories_bloc.dart
+++ b/examples/flutter_bloc/lib/extended_bloc/repositories_bloc.dart
@@ -13,6 +13,8 @@ class RepositoriesBloc extends GraphqlBloc<Map<String, dynamic>> {
                 documentNode: parseString(r'''
                   query ReadRepositories($nRepositories: Int!, $after: String) {
                       viewer {
+                        id
+                        __typename
                         repositories(first: $nRepositories, after: $after) {
                           pageInfo {
                             endCursor
@@ -53,11 +55,6 @@ class RepositoriesBloc extends GraphqlBloc<Map<String, dynamic>> {
   void fetchMore({String after}) {
     add(GraphqlFetchMoreEvent(
         options: FetchMoreOptions(
-//      variables: ReportListArguments(
-//          pagination: PaginationInput(
-//        limit: limit,
-//        offset: offset,
-//      )).toJson(),
       variables: <String, dynamic>{'nRepositories': 5, 'after': after},
       updateQuery: (dynamic previousResultData, dynamic fetchMoreResultData) {
         final List<dynamic> repos = <dynamic>[

--- a/examples/flutter_bloc/lib/main.dart
+++ b/examples/flutter_bloc/lib/main.dart
@@ -15,6 +15,10 @@ import 'local.dart';
 
 void main() => runApp(MyApp());
 
+final OptimisticCache cache = OptimisticCache(
+  dataIdFromObject: typenameDataIdFromObject,
+);
+
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -55,9 +59,7 @@ class MyApp extends StatelessWidget {
     final Link _link = _authLink.concat(_httpLink);
 
     return GraphQLClient(
-      cache: OptimisticCache(
-        dataIdFromObject: typenameDataIdFromObject,
-      ),
+      cache: cache,
       link: _link,
     );
   }


### PR DESCRIPTION
In case of resolving from cache the 'loading' initial state show the
loading indicator each time the query renders.

Moved cache instantiation out of `_client` to make cache work.
Otherwise cache instance was always recreated.

### Breaking changes

- no breaking changes

#### Fixes / Enhancements

- Updated - bloc sample to include initial state
- Fixed - moved cache instantiation out of `_client` to make cache work
