### PR TITLE
Prevent PersistedQueriesLink from crashing

### DIFF
--- a/packages/graphql/lib/src/link/apq/link_persisted_queries.dart
+++ b/packages/graphql/lib/src/link/apq/link_persisted_queries.dart
@@ -167,17 +167,20 @@ class PersistedQueriesLink extends Link {
         ));
   } 
 
-  StreamSubscription _attachListener(StreamController<FetchResult> controller, Stream<FetchResult> stream, Function retry) {
+  StreamSubscription _attachListener(StreamController<FetchResult> controller,
+      Stream<FetchResult> stream, Function retry) {
     return stream.listen(
       (data) {
-        retry(response: data, callback: () => 
-          controller.add(data)
-        );
+        retry(response: data, callback: () => controller.add(data));
       },
       onError: (err) {
-        retry(networkError: ex.translateFailure(err), callback: () => 
-          controller.addError(err)
-        );
+        if (err is UnhandledFailureWrapper) {
+          controller.addError(err);
+        } else {
+          retry(
+              networkError: ex.translateFailure(err),
+              callback: () => controller.addError(err));
+        }
       },
       onDone: () {
         controller.close();


### PR DESCRIPTION
When the error was an `UnhandledFailureWrapper`, the retry mechanism was crashing with an exception that could not be caught from the outside. The retry request must only be made when the error can be handled and not for `UnhandledFailureWrapper` errors.
This, for example, happens when the server responded with a `403 Forbidden` error.
