### PR TITLE
Update README upload section

### DIFF
--- a/packages/graphql_flutter/README.md
+++ b/packages/graphql_flutter/README.md
@@ -551,16 +551,18 @@ mutation($files: [Upload!]!) {
 ```
 
 ```dart
-import 'dart:io' show File;
+import 'package:http/http.dart';
 
 // ...
 
 String filePath = '/aboslute/path/to/file.ext';
+final file = await multipartFileFrom(File(filePath));
+
 final QueryResult r = await graphQLClientClient.mutate(
   MutationOptions(
     documentNode: gql(uploadMutation),
     variables: {
-      'files': [File(filePath)],
+      'files': [file],
     },
   )
 );


### PR DESCRIPTION
The direct file usage is deprecated 
https://github.com/zino-app/graphql-flutter/blob/master/packages/graphql/lib/src/link/http/link_http_helper_deprecated_io.dart#L24

### Breaking changes

- no

#### Docs

- Updated - upload file `README` section
