### PR TITLE
fix: in memory html fails if it gets a future

### DIFF
--- a/packages/graphql/lib/src/cache/in_memory_html.dart
+++ b/packages/graphql/lib/src/cache/in_memory_html.dart
@@ -12,12 +12,13 @@ import 'package:graphql/src/utilities/helpers.dart' show deeplyMergeLeft;
 class InMemoryCache implements Cache {
   InMemoryCache({
     this.storagePrefix = '',
-  }) {
-    masterKey = storagePrefix ?? '' + '_graphql_cache';
-  }
+  });
 
-  final String storagePrefix;
-  String masterKey;
+  final FutureOr<String> storagePrefix;
+
+  Future<String> masterKey() async {
+    return await storagePrefix ?? '' + '_graphql_cache';
+  }
 
   @protected
   HashMap<String, dynamic> data = HashMap<String, dynamic>();
@@ -68,12 +69,12 @@ class InMemoryCache implements Cache {
   }
 
   Future<dynamic> _writeToStorage() async {
-    window.localStorage[masterKey] = jsonEncode(data);
+    window.localStorage[await masterKey()] = jsonEncode(data);
   }
 
   Future<HashMap<String, dynamic>> _readFromStorage() async {
     try {
-      final decoded = jsonDecode(window.localStorage[masterKey]);
+      final decoded = jsonDecode(window.localStorage[await masterKey()]);
       return HashMap.from(decoded);
     } catch (error) {
       // TODO: handle error


### PR DESCRIPTION
#### Fixes / Enhancements
Currently the star wars example is broken when using flutter web, this fixes it.

I'm not able to get the star wars server running because the angle graphql server is trying to access the message of a typeerror. But I tested it with a javascript version. Don't know if it functions completely but at least it doesn't break as badly.