### PR TITLE
fix(client): FetchMoreOptions bug with operator precedence

### DIFF
--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -346,7 +346,7 @@ class FetchMoreOptions {
         assert(updateQuery != null),
         this.documentNode =
             // ignore: deprecated_member_use_from_same_package
-            documentNode ?? document != null ? parseString(document) : null;
+            documentNode ?? (document != null ? parseString(document) : null);
 
   DocumentNode documentNode;
 

--- a/packages/graphql/test/core/query_options_test.dart
+++ b/packages/graphql/test/core/query_options_test.dart
@@ -1,0 +1,42 @@
+import 'package:gql/language.dart';
+import 'package:graphql/client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FetchMoreOptions', () {
+    group('constructs', () {
+      final dummyUpdateQuery = (previousResultData, fetchMoreResultData) {
+        return null;
+      };
+
+      final document = 'query { foo }';
+      final documentParsed = parseString(document);
+
+      final documentNode = parseString('query { bar }');
+
+      test('with documentNode', () {
+        final options = FetchMoreOptions(
+          documentNode: documentNode,
+          updateQuery: dummyUpdateQuery,
+        );
+        expect(options.documentNode, equals(documentNode));
+      });
+
+      test('with document', () {
+        final options = FetchMoreOptions(
+          // ignore: deprecated_member_use_from_same_package
+          document: document,
+          updateQuery: dummyUpdateQuery,
+        );
+        expect(options.documentNode, equals(documentParsed));
+      });
+
+      test('with neither', () {
+        final options = FetchMoreOptions(
+          updateQuery: dummyUpdateQuery,
+        );
+        expect(options.documentNode, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
This PR fixes a bug in FetchMoreOptions's constructor that will throw when documentNode parameter is non-null, which is due to `??` having higher precedence than `? :`.

### Breaking changes

- There should be NO breaking change because:
  - When documentNode is non-null, old code will throw (but wrongly), new code will not
  - When documentNode is null, both code will give the same result

Note: I feel that it might be better for this PR to merge into master instead of into beta, since it is a pure non-breaking bug fix.