### PR TITLE
fix: run onError callback before onCompleted

### DIFF
--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -178,7 +178,7 @@ class MutationCallbacks {
   // callbacks will be called against each result in the stream,
   // which should then rebroadcast queries with the appropriate optimism
   Iterable<OnData> get callbacks =>
-      <OnData>[onCompleted, update, onError].where(notNull);
+      <OnData>[onError, update, onCompleted].where(notNull);
 
   // Todo: probably move this to its own class
   OnData get onCompleted {

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -1,14 +1,18 @@
 name: graphql_flutter
-description: A GraphQL client for Flutter, bringing all the features from a modern
+description:
+  A GraphQL client for Flutter, bringing all the features from a modern
   GraphQL client to one easy to use package.
 version: 3.0.2
 authors:
-- Eus Dima <eus@zinoapp.com>
-- Zino Hofmann <zino@zinoapp.com>
-- Michael Joseph Rosenthal <rosenthalm93@gmail.com>
+  - Eus Dima <eus@zinoapp.com>
+  - Zino Hofmann <zino@zinoapp.com>
+  - Michael Joseph Rosenthal <rosenthalm93@gmail.com>
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
 dependencies:
-  graphql: ^3.0.2
+  graphql:
+    git:
+      url: https://github.com/ronaldcurtis/graphql-flutter.git
+      path: packages/graphql
   flutter:
     sdk: flutter
   meta: ^1.1.6
@@ -23,4 +27,4 @@ dev_dependencies:
     sdk: flutter
   test: ^1.5.3
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
Fixes https://github.com/zino-app/graphql-flutter/issues/680 https://github.com/zino-app/graphql-flutter/issues/643

**Fixes / Enhancements**
As a developer executing a mutation request
When I receive an error from the server
Then I should be able to react to this error in the onError callback, before the onCompleted callback is run.

**Example use case:**
In my app, I allow the user to update his/her username. And then I Navigator.of(context).pop to the previous route after the mutation. But I don't want to pop the screen if there's an error. Instead I want to be able to show some kind of error message.