### PR TITLE
fix starwars example dependency

### DIFF
--- a/examples/starwars/pubspec.yaml
+++ b/examples/starwars/pubspec.yaml
@@ -4,13 +4,13 @@ description: An example graphql_flutter application utilizing graphql_starwars_t
 dependencies:
   flutter:
     sdk: flutter
-  graphql_flutter: 
+  graphql_flutter:
     path: ../../packages/graphql_flutter
   graphql:
     path: ../../packages/graphql
   universal_platform: ^0.1.3
     # https://github.com/flutter/flutter/issues/36126#issuecomment-596215587
-  graphql_starwars_test_server: 
+  graphql_starwars_test_server:
     git: git@github.com:micimize/angel-starwars-test-server.git
 
 flutter:
@@ -24,7 +24,6 @@ dependency_overrides:
   graphql_server:
     git:
       url: git@github.com:micimize/angel.git
-      ref: typeerror2.8-fix
       path: packages/graphql/graphql_server
   graphql_parser:
     git:


### PR DESCRIPTION
- Fixed sample app dependency error

```

Git error. Command: `git rev-list --max-count=1 typeerror2.8-fix`
stdout:
stderr: fatal: ambiguous argument 'typeerror2.8-fix': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
exit code: 128
pub get failed (server unavailable) -- attempting retry 1 in 1 second...
Running "flutter pub get" in starwars...
```