### PR TITLE
Check for nullable keepAliveSubscription

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -261,15 +261,12 @@ class SocketClient {
   Future<void> dispose() async {
     print('Disposing socket client..');
     _reconnectTimer?.cancel();
-    final closing = [
+    await Future.wait([
       socket?.close(),
       _messageSubscription?.cancel(),
       _connectionStateController?.close(),
-    ];
-    if (_keepAliveSubscription != null) {
-      closing.add(_keepAliveSubscription?.cancel());
-    }
-    await Future.wait(closing);
+      _keepAliveSubscription?.cancel()
+    ].where((future) => future != null).toList());
   }
 
   static GraphQLSocketMessage _parseSocketMessage(dynamic message) {

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -261,12 +261,15 @@ class SocketClient {
   Future<void> dispose() async {
     print('Disposing socket client..');
     _reconnectTimer?.cancel();
-    await Future.wait([
+    final closing = [
       socket?.close(),
-      _keepAliveSubscription?.cancel(),
       _messageSubscription?.cancel(),
       _connectionStateController?.close(),
-    ]);
+    ];
+    if (_keepAliveSubscription != null) {
+      closing.add(_keepAliveSubscription?.cancel());
+    }
+    await Future.wait(closing);
   }
 
   static GraphQLSocketMessage _parseSocketMessage(dynamic message) {


### PR DESCRIPTION
Check for nullable ```keepAliveSubscription``` when disposing ```SocketClient```.

**Fixes**
- Fixed ```dispose``` function of ```SocketClient```, it didn't check the nullable ```keepAliveSubscription``` before put it into ```Future.wait```.  If ```SocketClientConfig``` constructed with null ```inactivityTimeout```, ```keepAliveSubscription``` won't be initialized which results in the exception in ```Future.wait```.