### PR TITLE
Implement toJson encoding for DateTime objects.

### DIFF
--- a/packages/graphql/lib/src/core/raw_operation_data.dart
+++ b/packages/graphql/lib/src/core/raw_operation_data.dart
@@ -85,6 +85,12 @@ class RawOperationData {
       if (isIoFile(object)) {
         return object.path;
       }
+      
+      // Better support for DateTime objects.
+      if (object is DateTime) {
+        return object.toIso8601String();
+      }
+      
       // default toEncodable behavior
       return object.toJson();
     });


### PR DESCRIPTION
DateTime does not have a toJson() default encoding.

Using this object in GQL mutations always fails.

Describe the purpose of the pull request.

### Breaking changes

- None.

#### Fixes / Enhancements

- Fixed DateTime objects being used in GQL queries/mutations.
- Added toJson() support for DateTime.
- Updated toKey() function.
