### PR TITLE
Migrate to web_socket_channel (re-PR of #818)

### DIFF
--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -17,10 +17,11 @@ dependencies:
   normalize: ^0.5.0-nullsafety.0
   http: ^0.13.0
   collection: ^1.14.12
-  websocket: ^0.0.5
+  web_socket_channel: ^2.0.0
   rxdart: ^0.26.0
-  uuid_enhanced: ^3.0.2
+  uuid: ^3.0.1
 dev_dependencies:
+  async: ^2.5.0
   pedantic: ^1.8.0+1
   mockito: ^4.0.0
   test: ^1.5.3

--- a/packages/graphql_flutter/test/widgets/query_test.dart
+++ b/packages/graphql_flutter/test/widgets/query_test.dart
@@ -99,6 +99,7 @@ class PageState extends State<Page> {
 void main() {
   setUpAll(() async {
     await mockApplicationDocumentsDirectory();
+    await initHiveForFlutter();
   });
 
   group('Query', () {
@@ -107,8 +108,6 @@ void main() {
     ValueNotifier<GraphQLClient> client;
 
     setUp(() async {
-      await initHiveForFlutter();
-
       mockHttpClient = MockHttpClient();
       httpLink = HttpLink(
         'https://unused/graphql',


### PR DESCRIPTION
This is a re-opening of #818 because I'm a dumbass.

Thanks to @renancaraujo for doing the bulk of the work here (opened the initial PR)

### Breaking changes

- This breaks the constructor signature and some public fields of the `SocketClient` class

#### Fixes / Enhancements

- Migrated dependencies to [web_socket_channel](https://pub.dev/packages/web_socket_channel) as described on #817
- Migrates to `uuid`, closing #825
- Adds `connect` as a `SocketConfig` option, supplying an easier way for users to access the `socketChannel` and add `headers`:
  ```dart
  connect: (url, protocols) =>
    IOWebSocketChannel.connect(url, protocols: protocols, headers: myCustomHeaders)
  ```