### PR TITLE
Fix AuthLink to allow null token to be returned

### DIFF
--- a/packages/graphql/lib/src/links/auth_link.dart
+++ b/packages/graphql/lib/src/links/auth_link.dart
@@ -25,14 +25,14 @@ class AuthLink extends _AsyncReqTransformLink {
   }) : super(requestTransformer: transform(headerKey, getToken));
 
   /// Authentication callback. Note – must include prefixes, e.g. `'Bearer $token'`
-  final FutureOr<String>? Function() getToken;
+  final FutureOr<String?> Function() getToken;
 
   /// Header key to set to the result of [getToken]
   final String headerKey;
 
   static _RequestTransformer transform(
     String headerKey,
-    FutureOr<String>? Function() getToken,
+    FutureOr<String?> Function() getToken,
   ) =>
       (Request request) async {
         final token = await getToken();


### PR DESCRIPTION
This fixes a problem where the AuthLink `getToken` function cannot return null as per https://github.com/zino-app/graphql-flutter/issues/797#issuecomment-797461751.

An attempt to fix this was made in `5.0.0-nullsafety.2` but it has not been working for me. See below:

Currently `getToken` type is: `FutureOr<String>? Function()`

The below code:
```
authLink = AuthLink(
  getToken: () async {
    final token = await getToken();
    return token == null ? null : 'Bearer $token';
  },
);
```
causes the following error when the Future tries to return null:
`The return type 'String?' isn't a 'Future<String>', as required by the closure's context.`

Changing `getToken` type to: `FutureOr<String?> Function()` removes the error and works as expected.