### PR TITLE
Capture stack traces in UnknownExceptions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "23 * * * *"
+          cron: "0 12 * * *"
           filters:
             branches:
               only:

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -101,13 +101,13 @@ class QueryManager {
             response,
             queryResult,
           );
-        } catch (failure) {
+        } catch (failure, trace) {
           // we set the source to indicate where the source of failure
           queryResult ??= QueryResult(source: QueryResultSource.network);
 
           queryResult.exception = coalesceErrors(
             exception: queryResult.exception,
-            linkException: translateFailure(failure),
+            linkException: translateFailure(failure, trace),
           );
         }
 
@@ -118,10 +118,10 @@ class QueryManager {
 
         return queryResult;
       }).transform(StreamTransformer.fromHandlers(
-        handleError: (err, trace, sink) => sink.add(_wrapFailure(err)),
+        handleError: (err, trace, sink) => sink.add(_wrapFailure(err, trace)),
       ));
-    } catch (ex) {
-      yield* Stream.fromIterable([_wrapFailure(ex)]);
+    } catch (ex, trace) {
+      yield* Stream.fromIterable([_wrapFailure(ex, trace)]);
     }
   }
 
@@ -218,13 +218,13 @@ class QueryManager {
         response,
         queryResult,
       );
-    } catch (failure) {
+    } catch (failure, trace) {
       // we set the source to indicate where the source of failure
       queryResult ??= QueryResult(source: QueryResultSource.network);
 
       queryResult.exception = coalesceErrors(
         exception: queryResult.exception,
-        linkException: translateFailure(failure),
+        linkException: translateFailure(failure, trace),
       );
     }
 
@@ -288,10 +288,10 @@ class QueryManager {
           );
         }
       }
-    } catch (failure) {
+    } catch (failure, trace) {
       queryResult.exception = coalesceErrors(
         exception: queryResult.exception,
-        linkException: translateFailure(failure),
+        linkException: translateFailure(failure, trace),
       );
     }
 
@@ -504,8 +504,8 @@ class QueryManager {
   }
 }
 
-QueryResult _wrapFailure(dynamic ex) => QueryResult(
+QueryResult _wrapFailure(dynamic ex, trace) => QueryResult(
       // we set the source to indicate where the source of failure
       source: QueryResultSource.network,
-      exception: coalesceErrors(linkException: translateFailure(ex)),
+      exception: coalesceErrors(linkException: translateFailure(ex, trace)),
     );

--- a/packages/graphql/lib/src/exceptions/exceptions.dart
+++ b/packages/graphql/lib/src/exceptions/exceptions.dart
@@ -11,9 +11,10 @@ import 'package:graphql/src/exceptions/network.dart'
 export 'package:graphql/src/exceptions/network.dart'
     if (dart.library.io) 'package:graphql/src/exceptions/network_io.dart';
 
-LinkException translateFailure(dynamic failure) {
+LinkException translateFailure(dynamic failure, StackTrace trace) {
   if (failure is LinkException) {
     return failure;
   }
-  return network.translateFailure(failure) ?? UnknownException(failure);
+  return network.translateFailure(failure) ??
+      UnknownException(failure, trace);
 }

--- a/packages/graphql/lib/src/exceptions/exceptions_next.dart
+++ b/packages/graphql/lib/src/exceptions/exceptions_next.dart
@@ -127,12 +127,16 @@ class UnexpectedResponseStructureException extends ServerException
 class UnknownException extends LinkException {
   String get message => 'Unhandled Client-Side Exception: $originalException';
 
+  final StackTrace originalStackTrace;
+
   const UnknownException(
     dynamic originalException,
+    this.originalStackTrace,
   ) : super(originalException);
 
   @override
-  String toString() => "UnknownException($originalException)";
+  String toString() =>
+      "UnknownException($originalException, stack:\n$originalStackTrace\n)";
 }
 
 /// Container for both [graphqlErrors] returned from the server

--- a/packages/graphql/lib/src/exceptions/exceptions_next.dart
+++ b/packages/graphql/lib/src/exceptions/exceptions_next.dart
@@ -127,6 +127,7 @@ class UnexpectedResponseStructureException extends ServerException
 class UnknownException extends LinkException {
   String get message => 'Unhandled Client-Side Exception: $originalException';
 
+  /// stacktrace of the [originalException].
   final StackTrace originalStackTrace;
 
   const UnknownException(


### PR DESCRIPTION
#### Fixes / Enhancements
- Added 
We've been running into exceptions that are pretty tricky to nail down without more context, and I was thinking that the inclusion of stack traces in UnknownExceptions would be helpful for us, and everybody else!

Related to https://github.com/nhost/nhost-dart/issues/9