### PR TITLE
Migrate to connectivity_plus

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/subscription.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:connectivity/connectivity.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/widgets.dart';
 import 'package:graphql/client.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.3.0
   path_provider: ^2.0.1
   path: ^1.8.0
-  connectivity: ^3.0.2
+  connectivity_plus: ^1.0.1
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
 dev_dependencies:


### PR DESCRIPTION
As requested in https://github.com/zino-app/graphql-flutter/issues/848 this migrates the package from using `connectivity` which is now deprecated to `connectivity_plus` which is the recommended option as per the flutter.dev:

https://pub.dev/packages/connectivity

> Deprecation Notice 
This plugin has been replaced by the Flutter Community Plus Plugins version, connectivity_plus. No further updates are planned to this plugin, and we encourage all users to migrate to the Plus version.
>
>Critical fixes (e.g., for any security incidents) will be provided through the end of 2021, at which point this package will be marked as discontinued.

It's a simple enough changes which only requires pointing to the new package, no code change outside of the import statement.

### Breaking changes

- N/A

#### Fixes / Enhancements

- Will fix https://github.com/zino-app/graphql-flutter/issues/848
- Staying on the old package causes naming collision for apps which have migrated to `connectivity_plus`, particularly regarding plugin registration for the web. See https://github.com/fluttercommunity/plus_plugins/issues/260 for more details.

