### PR TITLE
feat: Expose `possibleTypes` on cache

### DIFF
--- a/packages/graphql/lib/src/cache/_normalizing_data_proxy.dart
+++ b/packages/graphql/lib/src/cache/_normalizing_data_proxy.dart
@@ -17,6 +17,9 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
   /// `typePolicies` to pass down to `normalize`
   Map<String, TypePolicy> get typePolicies;
 
+  /// `possibleTypes` to pass down to [normalize]
+  Map<String, Set<String>> get possibleTypes;
+
   /// Optional `dataIdFromObject` function to pass through to [normalize]
   DataIdResolver? get dataIdFromObject;
 
@@ -92,6 +95,7 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
         document: request.operation.document,
         operationName: request.operation.operationName,
         variables: sanitizeVariables(request.variables)!,
+        possibleTypes: possibleTypes,
       );
 
   Map<String, dynamic>? readFragment(
@@ -112,6 +116,7 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
         idFields: fragmentRequest.idFields,
         fragmentName: fragmentRequest.fragment.fragmentName,
         variables: sanitizeVariables(fragmentRequest.variables)!,
+        possibleTypes: possibleTypes,
       );
 
   void writeQuery(
@@ -134,6 +139,7 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
         variables: sanitizeVariables(request.variables)!,
         // data
         data: data,
+        possibleTypes: possibleTypes,
       );
       if (broadcast ?? true) {
         broadcastRequested = true;
@@ -171,6 +177,7 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
         variables: sanitizeVariables(request.variables)!,
         // data
         data: data,
+        possibleTypes: possibleTypes,
       );
       if (broadcast ?? true) {
         broadcastRequested = true;

--- a/packages/graphql/lib/src/cache/_optimistic_transactions.dart
+++ b/packages/graphql/lib/src/cache/_optimistic_transactions.dart
@@ -44,6 +44,9 @@ class OptimisticProxy extends NormalizingDataProxy {
   /// `typePolicies` to pass down to `normalize` (proxied from [cache])
   get typePolicies => cache.typePolicies;
 
+  /// `possibleTypeOf` to pass down to `normalize` (proxied from [cache])
+  get possibleTypes => cache.possibleTypes;
+
   /// Optional `dataIdFromObject` function to pass through to [normalize]
   /// (proxied from [cache])
   get dataIdFromObject => cache.dataIdFromObject;

--- a/packages/graphql/lib/src/cache/cache.dart
+++ b/packages/graphql/lib/src/cache/cache.dart
@@ -32,6 +32,7 @@ class GraphQLCache extends NormalizingDataProxy {
     Store? store,
     this.dataIdFromObject,
     this.typePolicies = const {},
+    this.possibleTypes = const {},
     this.partialDataPolicy = PartialDataCachePolicy.acceptForOptimisticData,
     Object? Function(Object?) sanitizeVariables = sanitizeFilesForCache,
   })  : sanitizeVariables = variableSanitizer(sanitizeVariables),
@@ -59,6 +60,9 @@ class GraphQLCache extends NormalizingDataProxy {
 
   /// `typePolicies` to pass down to [normalize]
   final Map<String, TypePolicy> typePolicies;
+
+  /// `possibleTypes` to pass down to [normalize]
+  final Map<String, Set<String>> possibleTypes;
 
   /// Optional `dataIdFromObject` function to pass through to [normalize]
   final DataIdResolver? dataIdFromObject;

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   gql_error_link: ^0.2.0
   gql_dedupe_link: ^2.0.0
   hive: ^2.0.0
-  normalize: ^0.5.1
+  normalize: ^0.5.3
   http: ^0.13.0
   collection: ^1.15.0
   web_socket_channel: ^2.0.0


### PR DESCRIPTION
This PR exposes the `possibleTypes` of `normalize` allowing users to specify type inheritance

The field is released in `0.5.3` (see https://github.com/gql-dart/ferry/pull/199).

The map can be generated with [graphql_codegen](https://pub.dev/packages/graphql_codegen).

### Breaking changes

- None

#### Fixes / Enhancements

- Added `possibleTypes` field to cache.
- Passed `possibleTypes` to `normalize`.

#### Docs

- Expose `possibleTypes` from normalize on cache.
