### PR TITLE
connectivity_plus updated to 1.0.5

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.3.0
   path_provider: ^2.0.1
   path: ^1.8.0
-  connectivity_plus: ^1.0.1
+  connectivity_plus: ^1.0.2
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
 dev_dependencies:

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.3.0
   path_provider: ^2.0.1
   path: ^1.8.0
-  connectivity_plus: ^1.0.2
+  connectivity_plus: ^1.0.5
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
 dev_dependencies:


### PR DESCRIPTION
Describe the purpose of the pull request:

The connectivity_plus team fixed the naming collision issue in 1.0.2: https://github.com/fluttercommunity/plus_plugins/issues/260#issuecomment-855823911

That mean if some people were still on the deprecated connectivity for whatever reason, they could have received a warning after flutter_graphql moved to connectivity_plus. 

1.0.2 eliminates this concern without introducing any breaking changes. I think it is worth the minor revision increment on this package.

### Breaking changes

- N/A

#### Fixes / Enhancements

- Eliminates risk of naming collision with deprecated connectivity package for web enabled flutter apps using flutter_graphql.
