### PR TITLE
perf: open Hive boxes concurrently

### DIFF
--- a/packages/graphql_flutter/lib/src/hive_init.dart
+++ b/packages/graphql_flutter/lib/src/hive_init.dart
@@ -26,8 +26,6 @@ Future<void> initHiveForFlutter({String? subDir,  Iterable<String> boxes = const
     Hive.init(path);
   }
 
-  for (var box in boxes){
-    await Hive.openBox(box);
-  }
-
+  final futures = boxes.map(Hive.openBox);
+  await Future.wait(futures);
 }


### PR DESCRIPTION
This PR reduces initialization time taken by `initHiveForFlutter`.

### Breaking changes

- None.

#### Fixes / Enhancements

- Changed `initHiveForFlutter` to open boxes concurrently using [Future.wait](https://api.dart.dev/stable/2.13.4/dart-async/Future/wait.html)

#### Docs

- No changes.
