### PR TITLE
ci: try to upgrade the node version to make the package release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ aliases:
   - &flutter_environment
     - image: cirrusci/flutter:stable
   - &node_environment
-    - image: circleci/node:10
+    - image: circleci/node:16
   - &restore_cache
     keys:
       # when lock file changes, use increasingly general patterns to restore cache

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,4 +18,6 @@ coverage:
 # don't factor tests into coverage scores
 ignore:
   - packages/graphql_flutter/test
+  - packages/graphql_flutter/example
   - packages/graphql/test
+  - packages/graphql/example


### PR DESCRIPTION
This PR tries to fix the [following error](https://app.circleci.com/jobs/github/zino-app/graphql-flutter/13304?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)  and hopefully have the possibility to release the package with the new dependencies update