### PR TITLE
chore(graphql): upgrade normalize to 0.10.0 

### DIFF
--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   gql_error_link: ^1.0.0
   gql_dedupe_link: ^2.0.3
   hive_ce: ^2.11.0
-  normalize: '>=0.8.2 <0.10.0'
+  normalize: '>=0.8.2 <0.11.0'
   http: ^1.0.0
   collection: ^1.15.0
   web_socket_channel: '>=3.0.1 <4.0.0'


### PR DESCRIPTION

Last stable version of ferry updates the normalize dependencies to ^0.10.0 making main no longer compatible.

Newer version might not affect this package
[normalize | Dart changelog](https://pub.dev/packages/normalize/changelog)

