### PR TITLE
chore: bump graphql to 5.2.4 and graphql_flutter to 5.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           - stable
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{matrix.channel}}

--- a/.github/workflows/codcoverage.yml
+++ b/.github/workflows/codcoverage.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - name: Run tests with coverage

--- a/.github/workflows/codcoverage.yml
+++ b/.github/workflows/codcoverage.yml
@@ -15,12 +15,19 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-      - name: Run tests with coverage
-        run: |
-          make dep
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          make ci_coverage_client
-          ./codecov
-          make ci_coverage_flutter
-          ./codecov
+      - name: Install dependencies
+        run: make dep
+      - name: Run coverage (dart)
+        run: make ci_coverage_client
+      - name: Upload coverage (dart)
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: graphql
+      - name: Run coverage (flutter)
+        run: make ci_coverage_flutter
+      - name: Upload coverage (flutter)
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: graphql_flutter

--- a/.github/workflows/release_dart.yml
+++ b/.github/workflows/release_dart.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2 # required!
+        uses: actions/checkout@v4 # required!
 
       - name: 'publish graphql to to Pub.dev'
         uses: k-paxian/dart-package-publisher@master

--- a/.github/workflows/release_dart.yml
+++ b/.github/workflows/release_dart.yml
@@ -5,7 +5,6 @@ on:
     types: [created]
     tags:
       - graphql-v*
-  push:
   workflow_run:
     workflows:
       - "Test"

--- a/.github/workflows/release_flutter.yml
+++ b/.github/workflows/release_flutter.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2 # required!
+        uses: actions/checkout@v4 # required!
 
       - name: 'publish graphql-flutter to to Pub.dev'
         uses: k-paxian/dart-package-publisher@master

--- a/.github/workflows/release_flutter.yml
+++ b/.github/workflows/release_flutter.yml
@@ -5,7 +5,6 @@ on:
     types: [created]
     tags:
       - graphql_flutter-v*
-  push:
   workflow_run:
     workflows:
       - "Build"
@@ -27,5 +26,6 @@ jobs:
           credentialJson: ${{ secrets.CREDENTIAL_JSON }}
           flutter: true
           skipTests: true
+          force: true
           dryRunOnly: ${{ github.event_name != 'release' }}
           relativePath: './packages/graphql_flutter/'

--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: 'graphql publish to to Pub.dev'
         uses: k-paxian/dart-package-publisher@master
         with:
@@ -26,7 +26,7 @@ jobs:
       - publishing_client
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         # FIXME: when we bump a new release, we can have problem
         # in dry mode because the new release is not on the pub.dev
         # yet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - name: Install dependencies

--- a/packages/graphql/changelog.json
+++ b/packages/graphql/changelog.json
@@ -1,6 +1,6 @@
 {
     "package_name": "graphql",
-    "version": "v5.2.3",
+    "version": "v5.2.4",
     "api": {
         "name": "github",
         "repository": "zino-hofmann/graphql-flutter",

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -1,6 +1,6 @@
 name: graphql
 description: A stand-alone GraphQL client for Dart, bringing all the features from a modern GraphQL client to one easy to use package.
-version: 5.2.3
+version: 5.2.4
 repository: https://github.com/zino-app/graphql-flutter/tree/main/packages/graphql
 issue_tracker: https://github.com/zino-hofmann/graphql-flutter/issues
 

--- a/packages/graphql_flutter/changelog.json
+++ b/packages/graphql_flutter/changelog.json
@@ -1,6 +1,6 @@
 {
   "package_name": "graphql_flutter",
-  "version": "v5.2.1",
+  "version": "v5.3.0",
   "api": {
     "name": "github",
     "repository": "zino-hofmann/graphql-flutter",

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: graphql_flutter
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
-version: 5.2.1
+version: 5.3.0
 repository: https://github.com/zino-app/graphql-flutter/tree/main/packages/graphql_flutter
 issue_tracker: https://github.com/zino-hofmann/graphql-flutter/issues
 
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/zino-hofmann/graphql-flutter/issues
 # publish_to: 'none'
 
 dependencies:
-  graphql: ^5.2.2
+  graphql: ^5.2.4
   gql_exec: ^1.0.0+1
   flutter:
     sdk: flutter


### PR DESCRIPTION
graphql 5.2.4:
- fix: upgrade normalize dependency to be 0.10.0 compatible

graphql_flutter 5.3.0 (minor bump due to dependency changes):
- BREAKING: switched from `hive` to `hive_ce` - users importing `package:hive/hive.dart` directly should switch to `package:hive_ce/hive_ce.dart`
- chore: update connectivity_plus from ^6.1.3 to ^7.0.0
- fix: update flutter_hooks constraint to <0.22.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

There are some simple steps to get your PR merged, that are the following:

- Describe your PR and why a maintainer should merge it;
- Put the same description inside the commit body otherwise if we change github hosting you application will be based on a instable source code;
- Write the commit header in the way that it is following these simple rules [1]
- Make sure that your PR will pass the CI
- Wait for an review :smile: that will not happen if one of the previous step is missing.

[1](https://github.com/zino-hofmann/graphql-flutter/blob/main/docs/dev/MAINTAINERS.md#commit-style)

Fixes https://github.com/zino-hofmann/graphql-flutter/issues/1506

<!--
### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
-->
