### PR TITLE
feat(graphql): add cancellation support for queries and mutations

### DIFF
--- a/packages/graphql/lib/src/core/_base_options.dart
+++ b/packages/graphql/lib/src/core/_base_options.dart
@@ -24,6 +24,7 @@ abstract class BaseOptions<TParsed extends Object?> {
     CacheRereadPolicy? cacheRereadPolicy,
     this.optimisticResult,
     this.queryRequestTimeout,
+    this.cancellationToken,
   })  : policies = Policies(
           fetch: fetchPolicy,
           error: errorPolicy,
@@ -64,6 +65,12 @@ abstract class BaseOptions<TParsed extends Object?> {
   /// Override default query timeout
   final Duration? queryRequestTimeout;
 
+  /// Token that can be used to cancel the operation.
+  ///
+  /// When the token is cancelled, the operation will complete with
+  /// a [CancelledException].
+  final CancellationToken? cancellationToken;
+
   // TODO consider inverting this relationship
   /// Resolve these options into a request
   Request get asRequest => Request(
@@ -85,6 +92,7 @@ abstract class BaseOptions<TParsed extends Object?> {
         context,
         parserFn,
         queryRequestTimeout,
+        cancellationToken,
       ];
 
   OperationType get type {

--- a/packages/graphql/lib/src/core/cancellation_token.dart
+++ b/packages/graphql/lib/src/core/cancellation_token.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+/// A token that can be used to cancel an in-flight GraphQL operation.
+///
+/// Create a [CancellationToken] and pass it to [QueryOptions] or
+/// [MutationOptions] to enable cancellation of those operations.
+///
+/// Example:
+/// ```dart
+/// final token = CancellationToken();
+/// final result = client.query(
+///   QueryOptions(
+///     document: gql('query { ... }'),
+///     cancellationToken: token,
+///   ),
+/// );
+/// // Cancel the operation
+/// token.cancel();
+/// ```
+class CancellationToken {
+  bool _isCancelled = false;
+  final _controller = StreamController<void>.broadcast();
+
+  /// Whether this token has been cancelled.
+  bool get isCancelled => _isCancelled;
+
+  /// A stream that emits when cancellation is requested.
+  Stream<void> get onCancel => _controller.stream;
+
+  /// Cancel the operation associated with this token.
+  ///
+  /// Calling [cancel] multiple times has no additional effect.
+  void cancel() {
+    if (!_isCancelled) {
+      _isCancelled = true;
+      _controller.add(null);
+    }
+  }
+
+  /// Dispose of this token's resources.
+  ///
+  /// After calling [dispose], this token should not be used again.
+  void dispose() {
+    _controller.close();
+  }
+}
+
+/// Result wrapper that includes both the result future and a
+/// way to cancel the operation.
+class CancellableOperation<T> {
+  /// The future that will complete with the operation result.
+  final Future<T> result;
+
+  final CancellationToken _cancellationToken;
+
+  CancellableOperation({
+    required this.result,
+    required CancellationToken cancellationToken,
+  }) : _cancellationToken = cancellationToken;
+
+  /// Cancel this operation.
+  void cancel() => _cancellationToken.cancel();
+}

--- a/packages/graphql/lib/src/core/core.dart
+++ b/packages/graphql/lib/src/core/core.dart
@@ -1,6 +1,7 @@
 export 'package:gql_exec/gql_exec.dart';
 export 'package:gql_link/gql_link.dart';
 
+export 'package:graphql/src/core/cancellation_token.dart';
 export 'package:graphql/src/core/observable_query.dart';
 export 'package:graphql/src/core/query_manager.dart';
 export 'package:graphql/src/core/query_options.dart';

--- a/packages/graphql/lib/src/core/mutation_options.dart
+++ b/packages/graphql/lib/src/core/mutation_options.dart
@@ -31,6 +31,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     this.onError,
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
+    CancellationToken? cancellationToken,
   }) : super(
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -42,6 +43,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
           optimisticResult: optimisticResult,
           parserFn: parserFn,
           queryRequestTimeout: queryRequestTimeout,
+          cancellationToken: cancellationToken,
         );
 
   final OnMutationCompleted? onCompleted;
@@ -71,6 +73,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         onError: onError,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 
   WatchQueryOptions<TParsed> asWatchQueryOptions() =>
@@ -85,6 +88,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         context: context,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 }
 

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -6,6 +6,7 @@ import 'package:gql_link/gql_link.dart' show Link;
 import 'package:graphql/src/cache/cache.dart';
 import 'package:graphql/src/core/_base_options.dart';
 import 'package:graphql/src/core/_query_write_handling.dart';
+import 'package:graphql/src/core/cancellation_token.dart';
 import 'package:graphql/src/core/mutation_options.dart';
 import 'package:graphql/src/core/observable_query.dart';
 import 'package:graphql/src/core/policies.dart';
@@ -269,7 +270,12 @@ class QueryManager {
     bool rereadFromCache = false;
 
     try {
-      final completer = Completer<Response>();
+      // Check for pre-cancellation before executing the request
+      final cancellationToken = options.cancellationToken;
+      if (cancellationToken != null && cancellationToken.isCancelled) {
+        throw CancelledException('Operation was cancelled');
+      }
+
       // execute the request through the provided link(s)
       Stream<Response> responseStream = link.request(request);
 
@@ -281,17 +287,26 @@ class QueryManager {
         responseStream = responseStream.timeout(timeout);
       }
 
-      // Listen for the first response or error
-      responseStream.listen(completer.complete,
-          onError: (Object error, StackTrace stackTrace) {
-        if (!completer.isCompleted) {
-          // We return the first error encountered
-          completer.completeError(error, stackTrace);
-        }
-      });
+      // Race the response stream against the cancellation token,
+      // or use a completer to handle timeouts properly
+      if (cancellationToken != null) {
+        response = await _awaitWithCancellation(
+          responseStream,
+          cancellationToken,
+        );
+      } else {
+        final completer = Completer<Response>();
 
-      // Await the response or error
-      response = await completer.future;
+        // Listen for the first response or error
+        responseStream.listen(completer.complete,
+            onError: (Object error, StackTrace stackTrace) {
+          if (!completer.isCompleted) {
+            completer.completeError(error, stackTrace);
+          }
+        });
+
+        response = await completer.future;
+      }
 
       queryResult = mapFetchResultToQueryResult(
         response,
@@ -332,6 +347,54 @@ class QueryManager {
     }
 
     return queryResult;
+  }
+
+  /// Await the first response from [stream], but cancel if
+  /// [cancellationToken] fires first.
+  Future<Response> _awaitWithCancellation(
+    Stream<Response> stream,
+    CancellationToken cancellationToken,
+  ) {
+    final completer = Completer<Response>();
+    StreamSubscription<Response>? subscription;
+    StreamSubscription<void>? cancelSubscription;
+
+    cancelSubscription = cancellationToken.onCancel.listen((_) {
+      if (!completer.isCompleted) {
+        subscription?.cancel();
+        completer.completeError(
+          CancelledException('Operation was cancelled'),
+          StackTrace.current,
+        );
+      }
+    });
+
+    subscription = stream.listen(
+      (response) {
+        if (!completer.isCompleted) {
+          completer.complete(response);
+        }
+        subscription?.cancel();
+        cancelSubscription?.cancel();
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+        cancelSubscription?.cancel();
+      },
+      onDone: () {
+        cancelSubscription?.cancel();
+        if (!completer.isCompleted) {
+          completer.completeError(
+            StateError('Response stream completed without emitting a value'),
+            StackTrace.current,
+          );
+        }
+      },
+    );
+
+    return completer.future;
   }
 
   /// Add an eager cache response to the stream if possible,

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -30,6 +30,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     Duration? queryRequestTimeout,
     this.onComplete,
     this.onError,
+    CancellationToken? cancellationToken,
   }) : super(
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -41,6 +42,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
           optimisticResult: optimisticResult,
           parserFn: parserFn,
           queryRequestTimeout: queryRequestTimeout,
+          cancellationToken: cancellationToken,
         );
 
   final OnQueryComplete? onComplete;
@@ -73,6 +75,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     Duration? queryRequestTimeout,
     OnQueryComplete? onComplete,
     OnQueryError? onError,
+    CancellationToken? cancellationToken,
   }) =>
       QueryOptions<TParsed>(
         document: document ?? this.document,
@@ -88,6 +91,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         queryRequestTimeout: queryRequestTimeout ?? this.queryRequestTimeout,
         onComplete: onComplete ?? this.onComplete,
         onError: onError ?? this.onError,
+        cancellationToken: cancellationToken ?? this.cancellationToken,
       );
 
   QueryOptions<TParsed> withFetchMoreOptions(
@@ -121,6 +125,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         optimisticResult: optimisticResult,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 
   QueryOptions<TParsed> copyWithPolicies(Policies policies) => QueryOptions(
@@ -135,6 +140,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         context: context,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 }
 
@@ -152,6 +158,7 @@ class SubscriptionOptions<TParsed extends Object?>
     Context? context,
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
+    CancellationToken? cancellationToken,
   }) : super(
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -163,6 +170,7 @@ class SubscriptionOptions<TParsed extends Object?>
           optimisticResult: optimisticResult,
           parserFn: parserFn,
           queryRequestTimeout: queryRequestTimeout,
+          cancellationToken: cancellationToken,
         );
   SubscriptionOptions<TParsed> copyWithPolicies(Policies policies) =>
       SubscriptionOptions(
@@ -176,6 +184,7 @@ class SubscriptionOptions<TParsed extends Object?>
         context: context,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 }
 
@@ -196,6 +205,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
     Context? context,
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
+    CancellationToken? cancellationToken,
   })  : eagerlyFetchResults = eagerlyFetchResults ?? fetchResults,
         super(
           document: document,
@@ -209,6 +219,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
           optimisticResult: optimisticResult,
           parserFn: parserFn,
           queryRequestTimeout: queryRequestTimeout,
+          cancellationToken: cancellationToken,
         );
 
   /// Whether or not to fetch results every time a new listener is added.
@@ -250,6 +261,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
     Context? context,
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
+    CancellationToken? cancellationToken,
   }) =>
       WatchQueryOptions<TParsed>(
         document: document ?? this.document,
@@ -267,6 +279,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         context: context ?? this.context,
         parserFn: parserFn ?? this.parserFn,
         queryRequestTimeout: queryRequestTimeout ?? this.queryRequestTimeout,
+        cancellationToken: cancellationToken ?? this.cancellationToken,
       );
 
   WatchQueryOptions<TParsed> copyWithFetchPolicy(
@@ -287,6 +300,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         context: context,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
   WatchQueryOptions<TParsed> copyWithPolicies(
     Policies policies,
@@ -306,6 +320,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         context: context,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 
   WatchQueryOptions<TParsed> copyWithPollInterval(Duration? pollInterval) =>
@@ -324,6 +339,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         context: context,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 
   WatchQueryOptions<TParsed> copyWithVariables(
@@ -343,6 +359,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         context: context,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 
   WatchQueryOptions<TParsed> copyWithOptimisticResult(
@@ -362,6 +379,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         context: context,
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
+        cancellationToken: cancellationToken,
       );
 }
 

--- a/packages/graphql/lib/src/exceptions/exceptions_next.dart
+++ b/packages/graphql/lib/src/exceptions/exceptions_next.dart
@@ -7,6 +7,17 @@ import 'package:meta/meta.dart';
 export 'package:gql_exec/gql_exec.dart' show GraphQLError;
 export 'package:normalize/normalize.dart' show PartialDataException;
 
+/// Exception thrown when an operation is cancelled via a [CancellationToken].
+@immutable
+class CancelledException extends LinkException {
+  CancelledException(this.message) : super(null, null);
+
+  final String message;
+
+  @override
+  String toString() => 'CancelledException($message)';
+}
+
 /// A failure to find a response from the cache.
 ///
 /// Can occur when `cacheOnly=true`, or when the [request] was just written

--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -191,6 +191,80 @@ class GraphQLClient implements GraphQLDataProxy {
     return await queryManager.mutate(options.copyWithPolicies(policies));
   }
 
+  /// Executes a query that can be cancelled via the returned
+  /// [CancellableOperation].
+  ///
+  /// This is a convenience method that creates a [CancellationToken]
+  /// and returns both the result future and the token wrapped in a
+  /// [CancellableOperation].
+  ///
+  /// Example:
+  /// ```dart
+  /// final operation = client.queryCancellable(
+  ///   QueryOptions(document: gql('query { ... }')),
+  /// );
+  /// // Cancel if needed
+  /// operation.cancel();
+  /// final result = await operation.result;
+  /// ```
+  CancellableOperation<QueryResult<TParsed>> queryCancellable<TParsed>(
+    QueryOptions<TParsed> options,
+  ) {
+    final cancellationToken = CancellationToken();
+    final modifiedOptions = options.copyWithOptions(
+      cancellationToken: cancellationToken,
+    );
+    return CancellableOperation(
+      result: query(modifiedOptions),
+      cancellationToken: cancellationToken,
+    );
+  }
+
+  /// Executes a mutation that can be cancelled via the returned
+  /// [CancellableOperation].
+  ///
+  /// This is a convenience method that creates a [CancellationToken]
+  /// and returns both the result future and the token wrapped in a
+  /// [CancellableOperation].
+  ///
+  /// Example:
+  /// ```dart
+  /// final operation = client.mutateCancellable(
+  ///   MutationOptions(document: gql('mutation { ... }')),
+  /// );
+  /// // Cancel if needed
+  /// operation.cancel();
+  /// final result = await operation.result;
+  /// ```
+  CancellableOperation<QueryResult<TParsed>> mutateCancellable<TParsed>(
+    MutationOptions<TParsed> options,
+  ) {
+    final cancellationToken = CancellationToken();
+    final policies = defaultPolicies.mutate.withOverrides(options.policies);
+    final modifiedOptions = options.copyWithPolicies(policies);
+    // Create new options with the cancellation token
+    final cancellableOptions = MutationOptions<TParsed>(
+      document: modifiedOptions.document,
+      operationName: modifiedOptions.operationName,
+      variables: modifiedOptions.variables,
+      fetchPolicy: modifiedOptions.fetchPolicy,
+      errorPolicy: modifiedOptions.errorPolicy,
+      cacheRereadPolicy: modifiedOptions.cacheRereadPolicy,
+      context: modifiedOptions.context,
+      optimisticResult: modifiedOptions.optimisticResult,
+      onCompleted: modifiedOptions.onCompleted,
+      update: modifiedOptions.update,
+      onError: modifiedOptions.onError,
+      parserFn: modifiedOptions.parserFn,
+      queryRequestTimeout: modifiedOptions.queryRequestTimeout,
+      cancellationToken: cancellationToken,
+    );
+    return CancellableOperation(
+      result: queryManager.mutate(cancellableOptions),
+      cancellationToken: cancellationToken,
+    );
+  }
+
   /// This subscribes to a GraphQL subscription according to the options specified and returns a
   /// [Stream] which either emits received data or an error.
   ///

--- a/packages/graphql/test/cancellation_test.dart
+++ b/packages/graphql/test/cancellation_test.dart
@@ -31,7 +31,7 @@ void main() {
       token.dispose();
     });
 
-    test('calling cancel() multiple times has no effect', () {
+    test('calling cancel() multiple times has no effect', () async {
       final token = CancellationToken();
       int cancelCount = 0;
       token.onCancel.listen((_) => cancelCount++);
@@ -41,10 +41,9 @@ void main() {
 
       expect(token.isCancelled, isTrue);
       // Give the stream time to deliver
-      Future<void>.delayed(Duration(milliseconds: 10)).then((_) {
-        expect(cancelCount, equals(1));
-        token.dispose();
-      });
+      await Future<void>.delayed(Duration(milliseconds: 10));
+      expect(cancelCount, equals(1));
+      token.dispose();
     });
 
     test('onCancel stream emits when cancelled', () async {

--- a/packages/graphql/test/cancellation_test.dart
+++ b/packages/graphql/test/cancellation_test.dart
@@ -1,0 +1,285 @@
+import 'package:gql/language.dart';
+import 'package:graphql/client.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'helpers.dart';
+
+void main() {
+  late MockLink link;
+  late GraphQLClient client;
+
+  setUp(() {
+    link = MockLink();
+    client = GraphQLClient(
+      cache: getTestCache(),
+      link: link,
+    );
+  });
+
+  group('CancellationToken', () {
+    test('starts in non-cancelled state', () {
+      final token = CancellationToken();
+      expect(token.isCancelled, isFalse);
+      token.dispose();
+    });
+
+    test('cancel() sets isCancelled to true', () {
+      final token = CancellationToken();
+      token.cancel();
+      expect(token.isCancelled, isTrue);
+      token.dispose();
+    });
+
+    test('calling cancel() multiple times has no effect', () {
+      final token = CancellationToken();
+      int cancelCount = 0;
+      token.onCancel.listen((_) => cancelCount++);
+
+      token.cancel();
+      token.cancel();
+
+      expect(token.isCancelled, isTrue);
+      // Give the stream time to deliver
+      Future<void>.delayed(Duration(milliseconds: 10)).then((_) {
+        expect(cancelCount, equals(1));
+        token.dispose();
+      });
+    });
+
+    test('onCancel stream emits when cancelled', () async {
+      final token = CancellationToken();
+      final future = token.onCancel.first;
+      token.cancel();
+      await future; // should complete without timeout
+      token.dispose();
+    });
+  });
+
+  group('CancelledException', () {
+    test('is a LinkException', () {
+      final exception = CancelledException('test message');
+      expect(exception, isA<LinkException>());
+    });
+
+    test('toString contains message', () {
+      final exception = CancelledException('Operation was cancelled');
+      expect(exception.toString(), contains('Operation was cancelled'));
+    });
+  });
+
+  group('Query cancellation', () {
+    test('query can be cancelled with CancellationToken', () async {
+      final cancellationToken = CancellationToken();
+
+      when(link.request(any)).thenAnswer(
+        (_) => Stream.fromFuture(
+          Future.delayed(
+            Duration(milliseconds: 500),
+            () => Response(
+              data: <String, dynamic>{'test': 'data'},
+              response: {},
+            ),
+          ),
+        ),
+      );
+
+      final resultFuture = client.query(
+        QueryOptions(
+          document: parseString('query { test }'),
+          fetchPolicy: FetchPolicy.networkOnly,
+          cancellationToken: cancellationToken,
+        ),
+      );
+
+      // Cancel before the response arrives
+      await Future<void>.delayed(Duration(milliseconds: 10));
+      cancellationToken.cancel();
+
+      final result = await resultFuture;
+      expect(result.hasException, isTrue);
+      expect(result.exception, isA<OperationException>());
+      expect(result.exception!.linkException, isA<CancelledException>());
+
+      cancellationToken.dispose();
+    });
+
+    test('already-cancelled token causes immediate cancellation', () async {
+      final cancellationToken = CancellationToken();
+      cancellationToken.cancel(); // cancel before starting
+
+      when(link.request(any)).thenAnswer(
+        (_) => Stream.fromIterable([
+          Response(
+            data: <String, dynamic>{'test': 'data'},
+            response: {},
+          ),
+        ]),
+      );
+
+      final result = await client.query(
+        QueryOptions(
+          document: parseString('query { test }'),
+          fetchPolicy: FetchPolicy.networkOnly,
+          cancellationToken: cancellationToken,
+        ),
+      );
+
+      expect(result.hasException, isTrue);
+      expect(result.exception!.linkException, isA<CancelledException>());
+
+      cancellationToken.dispose();
+    });
+
+    test('completed query is not affected by late cancellation', () async {
+      final cancellationToken = CancellationToken();
+
+      when(link.request(any)).thenAnswer(
+        (_) => Stream.fromIterable([
+          Response(
+            data: <String, dynamic>{'test': 'data'},
+            response: {},
+          ),
+        ]),
+      );
+
+      final result = await client.query(
+        QueryOptions(
+          document: parseString('query { test }'),
+          cancellationToken: cancellationToken,
+        ),
+      );
+
+      // Cancel after completion
+      cancellationToken.cancel();
+
+      expect(result.data, equals({'test': 'data'}));
+      expect(result.hasException, isFalse);
+
+      cancellationToken.dispose();
+    });
+  });
+
+  group('Mutation cancellation', () {
+    test('mutation can be cancelled with CancellationToken', () async {
+      final cancellationToken = CancellationToken();
+
+      when(link.request(any)).thenAnswer(
+        (_) => Stream.fromFuture(
+          Future.delayed(
+            Duration(milliseconds: 500),
+            () => Response(
+              data: <String, dynamic>{
+                'createItem': {'id': '1'}
+              },
+              response: {},
+            ),
+          ),
+        ),
+      );
+
+      final resultFuture = client.mutate(
+        MutationOptions(
+          document: parseString('mutation { createItem { id } }'),
+          cancellationToken: cancellationToken,
+        ),
+      );
+
+      await Future<void>.delayed(Duration(milliseconds: 10));
+      cancellationToken.cancel();
+
+      final result = await resultFuture;
+      expect(result.hasException, isTrue);
+      expect(result.exception!.linkException, isA<CancelledException>());
+
+      cancellationToken.dispose();
+    });
+  });
+
+  group('queryCancellable convenience method', () {
+    test('returns CancellableOperation with cancel capability', () async {
+      when(link.request(any)).thenAnswer(
+        (_) => Stream.fromFuture(
+          Future.delayed(
+            Duration(milliseconds: 500),
+            () => Response(
+              data: <String, dynamic>{'test': 'data'},
+              response: {},
+            ),
+          ),
+        ),
+      );
+
+      final operation = client.queryCancellable(
+        QueryOptions(
+          document: parseString('query { test }'),
+          fetchPolicy: FetchPolicy.networkOnly,
+        ),
+      );
+
+      expect(operation, isA<CancellableOperation<QueryResult>>());
+
+      await Future<void>.delayed(Duration(milliseconds: 10));
+      operation.cancel();
+
+      final result = await operation.result;
+      expect(result.hasException, isTrue);
+      expect(result.exception!.linkException, isA<CancelledException>());
+    });
+
+    test('successful query through CancellableOperation', () async {
+      when(link.request(any)).thenAnswer(
+        (_) => Stream.fromIterable([
+          Response(
+            data: <String, dynamic>{'test': 'success'},
+            response: {},
+          ),
+        ]),
+      );
+
+      final operation = client.queryCancellable(
+        QueryOptions(
+          document: parseString('query { test }'),
+          fetchPolicy: FetchPolicy.networkOnly,
+        ),
+      );
+
+      final result = await operation.result;
+      expect(result.hasException, isFalse);
+      expect(result.data, equals({'test': 'success'}));
+    });
+  });
+
+  group('mutateCancellable convenience method', () {
+    test('returns CancellableOperation with cancel capability', () async {
+      when(link.request(any)).thenAnswer(
+        (_) => Stream.fromFuture(
+          Future.delayed(
+            Duration(milliseconds: 500),
+            () => Response(
+              data: <String, dynamic>{
+                'createItem': {'id': '1'}
+              },
+              response: {},
+            ),
+          ),
+        ),
+      );
+
+      final operation = client.mutateCancellable(
+        MutationOptions(
+          document: parseString('mutation { createItem { id } }'),
+        ),
+      );
+
+      expect(operation, isA<CancellableOperation<QueryResult>>());
+
+      await Future<void>.delayed(Duration(milliseconds: 10));
+      operation.cancel();
+
+      final result = await operation.result;
+      expect(result.hasException, isTrue);
+      expect(result.exception!.linkException, isA<CancelledException>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `CancellationToken` and `CancelledException` for cancelling in-flight GraphQL operations
- Add `cancellationToken` parameter to `QueryOptions`, `MutationOptions`, and all option subclasses
- Implement cancellation in `QueryManager` by racing the response stream against the cancellation signal (same pattern as the existing `timeout` mechanism)
- Add `queryCancellable()` and `mutateCancellable()` convenience methods on `GraphQLClient`
- Add comprehensive test suite (13 tests)

This is an alternative approach to #1510 that addresses the issues found during review:
- **No `HttpLink` replacement** — cancellation works at the `QueryManager` level, so it's compatible with any `Link` implementation including file uploads
- **No new dependencies** — no `web` package needed
- **No per-request `HttpClient` creation** — avoids destroying connection pooling
- **No string-based error detection** — uses typed `CancelledException` throughout
- **Proper `cancellationToken` propagation** — added to all `copyWith`/`copyWithPolicies` methods so the token is never silently dropped

Closes #181

## Test plan

- [x] All 13 new cancellation tests pass
- [x] All 106 existing tests pass (no regressions)
- [x] `dart analyze` — 0 issues
- [x] `dart format` — 0 changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)