### PR TITLE
Guard late stream events after queryRequestTimeout

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -281,14 +281,42 @@ class QueryManager {
         responseStream = responseStream.timeout(timeout);
       }
 
-      // Listen for the first response or error
-      responseStream.listen(completer.complete,
-          onError: (Object error, StackTrace stackTrace) {
-        if (!completer.isCompleted) {
-          // We return the first error encountered
-          completer.completeError(error, stackTrace);
-        }
-      });
+      // Listen for the first response or error.
+      //
+      // Both `onData` and `onError` must be guarded against completing the
+      // completer more than once. `Stream.timeout` forwards a
+      // `TimeoutException` to `onError` without cancelling the source
+      // subscription, so a late event (e.g. a successful response that
+      // arrives after the timeout has already settled the completer) can
+      // still be delivered. Completing an already-completed completer throws
+      // "Bad state: Future already completed" from inside this async callback,
+      // which escapes the surrounding try/catch and crashes the app.
+      //
+      // Once the completer is settled we cancel the subscription so the
+      // underlying request does not keep running after we have a result.
+      late final StreamSubscription<Response> subscription;
+      subscription = responseStream.listen(
+        (response) {
+          if (!completer.isCompleted) {
+            completer.complete(response);
+          }
+          subscription.cancel();
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!completer.isCompleted) {
+            // We return the first error encountered
+            completer.completeError(error, stackTrace);
+          }
+          subscription.cancel();
+        },
+        onDone: () {
+          // The stream closed without emitting; surface this the same way
+          // `Stream.first` used to so the awaiting future does not hang.
+          if (!completer.isCompleted) {
+            completer.completeError(StateError('No element'));
+          }
+        },
+      );
 
       // Await the response or error
       response = await completer.future;

--- a/packages/graphql/test/query_manager_test.dart
+++ b/packages/graphql/test/query_manager_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:gql/language.dart';
 import 'package:graphql/client.dart';
 import 'package:mockito/mockito.dart';
@@ -42,5 +44,57 @@ void main() {
       );
       client.queryManager.refetchQuery<dynamic>(observable.queryId);
     });
+
+    // Regression test for https://github.com/zino-hofmann/graphql-flutter/issues/1525
+    //
+    // When a request times out and the underlying link later delivers a
+    // successful response, the late event must be ignored rather than
+    // completing the already-settled completer (which used to throw an
+    // uncaught "Bad state: Future already completed").
+    test(
+      "late response after queryRequestTimeout does not crash",
+      () async {
+        final controller = StreamController<Response>();
+        when(
+          link.request(any),
+        ).thenAnswer((_) => controller.stream);
+
+        final timeoutClient = GraphQLClient(
+          cache: getTestCache(),
+          link: link,
+          queryRequestTimeout: const Duration(milliseconds: 50),
+        );
+
+        // The request never emits before the timeout fires.
+        final result = await timeoutClient.query(
+          QueryOptions<dynamic>(
+            document: parseString("{ fetchPerson { name } }"),
+          ),
+        );
+
+        expect(result.hasException, isTrue);
+        expect(result.exception!.linkException, isA<UnknownException>());
+        expect(
+          (result.exception!.linkException as UnknownException)
+              .originalException,
+          isA<TimeoutException>(),
+        );
+
+        // The real response arrives after the timeout already settled the
+        // request. This must not throw an uncaught error.
+        controller.add(
+          Response(
+            data: <String, dynamic>{
+              'fetchPerson': <String, dynamic>{'name': 'late'},
+            },
+            response: <String, dynamic>{},
+          ),
+        );
+        await controller.close();
+
+        // Pump the event loop so any late delivery would surface here.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- **What was broken:** With `queryRequestTimeout` set, a request that timed out and then received a *late successful response* crashed the app with `Bad state: Future already completed` (uncaught, fatal on iOS + Android). Regression introduced in `graphql` 5.2.4.
- **Root cause:** `QueryManager._resolveQueryOnNetwork` listened with an **unguarded** `onData` (`responseStream.listen(completer.complete, ...)`) while `onError` was guarded. `Stream.timeout` forwards a `TimeoutException` to `onError` *without cancelling the source subscription*, so when the real response arrived later it ran `completer.complete` on an already-completed completer — throwing from inside an async callback that escaped the surrounding `try/catch`.
- **The fix:** Guard `onData` like `onError`, capture the subscription and `cancel()` it once the completer settles (so the underlying request stops running too), and complete with an error on an empty stream via `onDone` to preserve the old `responseStream.first` semantics and avoid a hanging future.

Fixes #1525

## Test plan
- [x] `dart test packages/graphql` — all 94 tests pass
- [x] `dart analyze lib test` — no issues
- [x] New regression test `late response after queryRequestTimeout does not crash` reproduces `Bad state: Future already completed` against the buggy code (verified by reverting the fix) and passes with the fix
- [ ] CI passes