### PR TITLE
Fix typos in docs and comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ from the main (upstream) repository:
 
 ## <a name="rules"></a> Coding Rules
 
-see `doc/dev/MANTAINERS.md` file
+see `doc/dev/MAINTAINERS.md` file
 
 
 ## <a name="commit"></a> Commit Message Guidelines
@@ -156,7 +156,7 @@ we use the git commit messages trigger releases.
 
 ### Commit Message Format
 
-see `doc/dev/MANTAINERS.md` file
+see `doc/dev/MAINTAINERS.md` file
  
 [github]: https://github.com/zino-app/graphql-flutter
 [discord]: https://discord.gg/tXTtBfC

--- a/packages/graphql_flutter/README.md
+++ b/packages/graphql_flutter/README.md
@@ -429,7 +429,7 @@ return FloatingActionButton(
 
 `GraphQLCache` allows for optimistic mutations by passing an `optimisticResult` to `RunMutation`. It will then call `update(GraphQLDataProxy cache, QueryResult result)` twice (once eagerly with `optimisticResult`), and rebroadcast all queries with the optimistic cache state.
 
-A complete and well-commented rundown of how exactly one interfaces with the `proxy` provided to `update` can be fount in the
+A complete and well-commented rundown of how exactly one interfaces with the `proxy` provided to `update` can be found in the
 [`GraphQLDataProxy` API docs](https://pub.dev/documentation/graphql/latest/graphql/GraphQLDataProxy-class.html)
 
 ```dart

--- a/packages/graphql_flutter/lib/src/widgets/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/subscription.dart
@@ -4,7 +4,7 @@ import 'package:graphql/client.dart';
 import 'package:graphql_flutter/src/widgets/hooks/graphql_client.dart';
 import 'package:graphql_flutter/src/widgets/hooks/subscription.dart';
 
-/// Creats a subscription with [GraphQLClient.subscribe].
+/// Creates a subscription with [GraphQLClient.subscribe].
 ///
 /// The [builder] is passed a [QueryResult] with only the **most recent**
 /// `data`. [ResultAccumulator] can be used to accumulate results.
@@ -78,7 +78,7 @@ class Subscription<TParsed> extends HookWidget {
   }
 }
 
-/// Creats a subscription widget like [Subscription] but
+/// Creates a subscription widget like [Subscription] but
 /// with an external client.
 class SubscriptionOnClient<TParsed> extends HookWidget {
   const SubscriptionOnClient({


### PR DESCRIPTION
Fixes small typos: "MANTAINERS" → "MAINTAINERS" (`CONTRIBUTING.md`), "fount" → "found" (`README.md`), and "Creats" → "Creates" (dartdoc in `subscription.dart`).